### PR TITLE
DEVSITE-239 Updated links in footer and header

### DIFF
--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -5,7 +5,7 @@ if(window.location.host.indexOf('hlx.page') >= 0 || window.location.host.indexOf
   $IS_HLX_PATH = true;
 }
 
-if(window.location.host.indexOf('stage.adobe.io') >= 0 || window.location.host.indexOf('developers-stage') >= 0){
+if(window.location.host.indexOf('stage.adobe.io') >= 0 || window.location.host.indexOf('developer-stage') >= 0){
   $IS_STAGE = true;
 }
 
@@ -105,22 +105,22 @@ const $HEADER_LINKS =
   {
     "name" : "Home",
     "links" : [
-      { "url": 'https://www.adobe.io' }
+      { "url": 'https://developer.adobe.com/' }
     ]
   },
   {
     "name" : "Products",
     "links" : [
-      { "url": 'https://www.adobe.io/apis' }
+      { "url": 'https://developer.adobe.com/apis' }
     ]
   },
   {
     "name" : "Community",
     "links" : [
       { "name": "Tech Blog", "url": 'https://medium.com/adobetech' },
-      { "name": "Open Source at Adobe", "url": 'https://www.adobe.io/open' },
+      { "name": "Open Source at Adobe", "url": 'https://developer.adobe.com/open' },
       { "name": "Adobe on Github", "url": 'https://github.com/adobe' },
-      { "name": "Developer Support", "url": 'https://www.adobe.io/support' },
+      { "name": "Adobe Developer Support", "url": 'https://developer.adobe.com/developer-support/' },
       { "name": "Experience League Community", "url": 'https://www.adobe.com/communities/index.html' },
     ]
   }
@@ -131,18 +131,16 @@ const $FOOTER_LINKS =
   {
     "name": "Api",
     "links": [
-      { "name": "Adobe Creative Cloud", "url": "https://www.adobe.io/apis/creativecloud" },
-      { "name": "Adobe Experience Platform", "url": "https://www.adobe.io/apis/experienceplatform/home" },
-      { "name": "Adobe Document Cloud", "url": "https://www.adobe.io/apis/documentcloud" },
-      { "name": "Adobe Experience Cloud", "url": "https://www.adobe.io/apis/experiencecloud" }
+      { "name": "Adobe Creative Cloud", "url": "https://developer.adobe.com/creative-cloud/" },
+      { "name": "Adobe Experience Platform", "url": "https://developer.adobe.com/experience-platform-apis/" },
+      { "name": "Adobe Document Cloud", "url": "https://developer.adobe.com/document-services/homepage" },
   ]
   },
   {
     "name": "Service",
     "links": [
-      { "name": "Adobe XD", "url": "https://www.adobe.io/apis/creativecloud/xd" },
-      { "name": "Adobe Target", "url": "https://www.adobe.io/apis/experiencecloud/target" },
-      { "name": "Adobe Analytics", "url": "https://www.adobe.io/apis/experiencecloud/analytics" },
+      { "name": "Adobe Cloud Manager", "url": "https://developer.adobe.com/experience-cloud/cloud-manager/"},
+      { "name": "Adobe Analytics", "url": "https://developer.adobe.com/analytics-apis/docs/2.0/" },
       { "name": "App Builder", "url": "https://developer.adobe.com/app-builder" }
     ]
   },
@@ -159,18 +157,17 @@ const $FOOTER_LINKS =
   {
     "name": "Support",
     "links": [
-      { "name": "Contact us", "url": "https://www.adobe.io/contactus" },
-      { "name": "Adobe Developer support", "url": "https://www.adobe.io/support" },
-      { "name": "Adobe Product support", "url": "https://helpx.adobe.com/contact/enterprise-support.html" }
+      { "name": "Adobe Developer Support", "url": "https://developer.adobe.com/developer-support/" },
+      { "name": "Adobe Product Support", "url": "https://helpx.adobe.com/contact/enterprise-support.html" }
     ]
   },
   {
     "name": "Developer",
       "links": [
       { "name": "Adobe Developer Console", "url": "https://developer.adobe.com/developer-console" },
-      { "name": "Open source at Adobe", "url": "https://www.adobe.io/open" },
+      { "name": "Open source at Adobe", "url": "https://developer.adobe.com/open" },
       { "name": "Download SDKs", "url": "https://developer.adobe.com/console/downloads" },
-      { "name": "Authentication", "url": "https://www.adobe.io/authentication.html" },
+      { "name": "Authentication", "url": "https://developer.adobe.com/developer-console/docs/guides/authentication/" },
       { "name": "Careers", "url": "https://adobe.com/careers.html" }
     ]
   },
@@ -333,7 +330,7 @@ let $CURRENT_API_FILTERS = [];
   }
 
   function isLinkExternal(url) {
-    if(url.indexOf('adobe.io') > -1 || url.indexOf('hlx.page') > -1 ){
+    if(url.indexOf('developer.adobe.com') > -1 || url.indexOf('hlx.page') > -1 ){
       return false;
     } else {
       return true;
@@ -427,7 +424,7 @@ let $CURRENT_API_FILTERS = [];
             <ul class="spectrum-Body spectrum-Body--sizeS">
               ${$apiLinksHTML}
               <li>
-                <a href="https://www.adobe.io/apis/" class="spectrum-Link spectrum-Link--quiet">
+                <a href="https://developer.adobe.com/apis/" class="spectrum-Link spectrum-Link--quiet">
                   <strong>
                     View all
                   </strong>
@@ -663,14 +660,14 @@ let $CURRENT_API_FILTERS = [];
   }
 
   function makeApiLinkRelative(link) {
-    if(link.indexOf('https://www.adobe.io/apis') >= 0){
+    if(link.indexOf('https://developer.adobe.com/apis') >= 0){
       if(window.location.pathname === '/apis') {
-        return link.replace('https://www.adobe.io/apis/','apis/');
+        return link.replace('https://developer.adobe.com/apis','apis/');
       } else if(window.location.pathname === '/apis/'){
-        return link.replace('https://www.adobe.io/apis/','./');
+        return link.replace('https://developer.adobe.com/apis','./');
       }
-    } else if (link.indexOf('https://www.adobe.io') >= 0) {
-      return link.replace('https://www.adobe.io','..');
+    } else if (link.indexOf('https://developer.adobe.com') >= 0) {
+      return link.replace('https://developer.adobe.com','..');
     } else {
       return link;
     }
@@ -791,10 +788,10 @@ let $CURRENT_API_FILTERS = [];
   function globalNavTemplate(links, searchButton = '') {
     return `
       <p class="icon-adobe-container">
-        <a href="https://adobe.io" class="nav-console-adobeio-link">
+        <a href="https://developer.adobe.com" class="nav-console-adobeio-link">
           <img class="icon icon-adobe" src="/hlx_statics/icons/adobe.svg" alt="adobe icon">
         </a>
-        <a href="https://adobe.io" class="nav-console-adobeio-link-text">
+        <a href="https://developer.adobe.com" class="nav-console-adobeio-link-text">
           <strong class="spectrum-Heading spectrum-Heading--sizeS icon-adobe-label">Adobe Developer</strong>
         </a>
       </p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated links in footer, header, and few general links to developer.adobe.com based.
script.js only has two adobe.io links left one for stage redirect and one for profile pictures.
Both confirmed to be left as is. The rest were updated.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
