### PR TITLE
Search iframe local search integration and loading improvement

### DIFF
--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -1186,7 +1186,9 @@ function isTopLevelNav(urlPathname) {
 }
 
 function decorateSearchIframeContainer($header) {
+  console.log("decorate");
   $header.querySelectorAll('div.nav-console-search-frame').forEach(($searchIframeContainer) => {
+    console.log("frame");
     const searchFrame = document.createElement('iframe');
     searchFrame.classList = "nav-search-iframe";
     searchFrame.src = setSearchFrameSource();
@@ -1194,12 +1196,14 @@ function decorateSearchIframeContainer($header) {
     const renderedFrame = $searchIframeContainer.firstChild;
 
     const searchFrameOnLoad = () => {
+      console.log("load");
       renderedFrame.contentWindow.postMessage(JSON.stringify({ localPathName: window.location.pathname }), '*');
       if ($SEARCH_PATH_NAME_CHECK !== window.location.pathname) {
         console.log("sending message again");
         window.setTimeout(searchFrameOnLoad, 100);
         return;
       }
+      console.log("load past message");
 
       // Past this point we successfully passed the local pathname and received a confirmation from the iframe
 
@@ -1209,7 +1213,7 @@ function decorateSearchIframeContainer($header) {
       }
 
       $header.querySelectorAll('button.nav-dropdown-search').forEach(($button) => {
-        console.log($button);
+        console.log("button event");
         $button.style.visibility = "visible";
 
         $button.addEventListener('click', (evt) => {

--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -34,6 +34,15 @@ const setExpectedOrigin = () => {
     return 'https://developer.adobe.com';
   }
 }
+const setTargetOrigin = () => {
+  const parentURL = document.referrer;
+
+  if (parentURL.indexOf('localhost') >= 0 || parentURL.indexOf('developer-stage.adobe') >= 0 || parentURL.indexOf('hlx.page') >= 0 || parentURL.indexOf('hlx.live') >= 0 || parentURL.indexOf('developer.adobe') >= 0) {
+    return parentURL;
+  } else {
+    return false;
+  }
+};
 const setSearchFrameSource = () => {
   const src = $IS_DEV ? setExpectedOrigin() : `${setExpectedOrigin()}/search-frame`;
   const queryString = getQueryString();
@@ -42,15 +51,27 @@ const setSearchFrameSource = () => {
   } else {
     return src;
   }
-}
-
+};
+/**
+ * WIP search Iframe communication pipeline
+ */
+// const dispatchFrameMessage = (message) => {
+//   const targetOrigin = setTargetOrigin();
+//   if (targetOrigin) {
+//     parent.postMessage(JSON.stringify(message), targetOrigin);
+//   }
+// };
+// const updateSearchFrameQueryParams = () => {
+//   const message = JSON.stringify({ 'query': '', 'keywords': '', 'index': '' });
+//   dispatchFrameMessage(message);
+// };
 
 window.addEventListener('message', function (e) {
   const expectedOrigin = setExpectedOrigin();
   if (e.origin !== expectedOrigin) return;
 
-  try{
-    if(typeof e == 'object') {
+  try {
+    if (typeof e == 'object') {
       const message = JSON.parse(e.data);
       setQueryStringParameter('query', message.query);
       setQueryStringParameter('keywords', message.keywords);
@@ -1177,6 +1198,11 @@ function isTopLevelNav(urlPathname) {
 function decorateSearchIframeContainer($header) {
   $header.querySelectorAll('div.nav-console-search-frame').forEach(($searchIframeContainer) => {
     const searchFrameOnLoad = () => {
+      const queryString = getQueryString();
+      if (queryString) {
+        $searchIframeContainer.style.visibility = 'visible';
+      }
+
       $header.querySelectorAll('button.nav-dropdown-search').forEach(($button) => {
         $button.style.visibility = "visible";
 

--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -1194,6 +1194,7 @@ function decorateSearchIframeContainer($header) {
     searchFrame.src = setSearchFrameSource();
     $searchIframeContainer.appendChild(searchFrame);
     const renderedFrame = $searchIframeContainer.firstChild;
+    let loaded = false;
 
     const searchFrameOnLoad = () => {
       console.log("load");
@@ -1203,32 +1204,36 @@ function decorateSearchIframeContainer($header) {
         window.setTimeout(searchFrameOnLoad, 100);
         return;
       }
-      console.log("load past message");
+
+      console.log(loaded);
 
       // Past this point we successfully passed the local pathname and received a confirmation from the iframe
+      if (!loaded) {
+        const queryString = getQueryString();
+        if (queryString) {
+          $searchIframeContainer.style.visibility = 'visible';
+        }
 
-      const queryString = getQueryString();
-      if (queryString) {
-        $searchIframeContainer.style.visibility = 'visible';
+        $header.querySelectorAll('button.nav-dropdown-search').forEach(($button) => {
+          console.log("button event");
+          $button.style.visibility = "visible";
+
+          $button.addEventListener('click', (evt) => {
+            if (!evt.currentTarget.classList.contains('is-open')) {
+              $button.classList.add('is-open');
+              $searchIframeContainer.style.visibility = 'visible';
+              console.log($searchIframeContainer);
+              document.body.style.overflow = 'hidden';
+            } else {
+              $button.classList.remove('is-open');
+              $searchIframeContainer.style.visibility = 'hidden';
+              document.body.style.overflow = 'auto';
+            }
+          });
+        })
       }
 
-      $header.querySelectorAll('button.nav-dropdown-search').forEach(($button) => {
-        console.log("button event");
-        $button.style.visibility = "visible";
-
-        $button.addEventListener('click', (evt) => {
-          if (!evt.currentTarget.classList.contains('is-open')) {
-            $button.classList.add('is-open');
-            $searchIframeContainer.style.visibility = 'visible';
-            console.log($searchIframeContainer);
-            document.body.style.overflow = 'hidden';
-          } else {
-            $button.classList.remove('is-open');
-            $searchIframeContainer.style.visibility = 'hidden';
-            document.body.style.overflow = 'auto';
-          }
-        });
-      })
+      loaded = true;
     }
 
     // Referenced https://stackoverflow.com/a/10444444/15028986

--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -53,19 +53,6 @@ const setSearchFrameSource = () => {
     return src;
   }
 };
-/**
- * WIP search Iframe communication pipeline
- */
-// const dispatchFrameMessage = (message, frame) => {
-//   const targetOrigin = "*"; //setTargetOrigin();
-//   if (targetOrigin) {
-//     frame.contentWindow.postMessage(JSON.stringify(message), targetOrigin);
-//   }
-// };
-// const updateSearchFrameQueryParams = () => {
-//   const message = JSON.stringify({ 'query': '', 'keywords': '', 'index': '' });
-//   dispatchFrameMessage(message);
-// };
 
 window.addEventListener('message', function (e) {
   const expectedOrigin = setExpectedOrigin();
@@ -1206,16 +1193,16 @@ function decorateSearchIframeContainer($header) {
     $searchIframeContainer.appendChild(searchFrame);
     const renderedFrame = $searchIframeContainer.firstChild;
 
-    const searchFramePostPathName = () => {
+    const searchFrameOnLoad = () => {
       renderedFrame.contentWindow.postMessage(JSON.stringify({ localPathName: window.location.pathname }), '*');
       if ($SEARCH_PATH_NAME_CHECK !== window.location.pathname) {
         console.log("sending message again");
         window.setTimeout(searchFrameOnLoad, 100);
         return;
       }
-    }
 
-    const searchFrameOnLoad = () => {
+      // Past this point we successfully passed the local pathname and received a confirmation from the iframe
+
       const queryString = getQueryString();
       if (queryString) {
         $searchIframeContainer.style.visibility = 'visible';
@@ -1229,6 +1216,7 @@ function decorateSearchIframeContainer($header) {
           if (!evt.currentTarget.classList.contains('is-open')) {
             $button.classList.add('is-open');
             $searchIframeContainer.style.visibility = 'visible';
+            console.log($searchIframeContainer);
             document.body.style.overflow = 'hidden';
           } else {
             $button.classList.remove('is-open');
@@ -1248,12 +1236,7 @@ function decorateSearchIframeContainer($header) {
       // Check if loading is complete
       if (iframeDoc.readyState === 'complete') {
         renderedFrame.onload = () => {
-          console.log("Pre pathname post");
-          searchFramePostPathName();
-          console.log("Post pathname post");
           searchFrameOnLoad();
-          console.log("Post onload btn should work");
-
         };
         // The loading is complete, call the function we want executed once the iframe is loaded
         return;

--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -1,7 +1,7 @@
 let $IS_HLX_PATH = false;
 let $IS_STAGE = false;
 let $IS_DEV = false;
-let $SEARCH_PRODUCT_RECEIVED = '';
+let $SEARCH_PATH_NAME_CHECK = '';
 
 if (window.location.host.indexOf('hlx.page') >= 0 || window.location.host.indexOf('hlx.live') >= 0 || window.location.host.indexOf('localhost') >= 0) {
   $IS_HLX_PATH = true;
@@ -62,6 +62,10 @@ const setSearchFrameSource = () => {
 //     frame.contentWindow.postMessage(JSON.stringify(message), targetOrigin);
 //   }
 // };
+// const updateSearchFrameQueryParams = () => {
+//   const message = JSON.stringify({ 'query': '', 'keywords': '', 'index': '' });
+//   dispatchFrameMessage(message);
+// };
 
 window.addEventListener('message', function (e) {
   const expectedOrigin = setExpectedOrigin();
@@ -74,7 +78,7 @@ window.addEventListener('message', function (e) {
       setQueryStringParameter('keywords', message.keywords);
       setQueryStringParameter('index', message.index);
     } else if (message.received) {
-      $SEARCH_PRODUCT_RECEIVED = message.received;
+      $SEARCH_PATH_NAME_CHECK = message.received;
     }
   } catch (e) {
     console.error(e);
@@ -93,7 +97,7 @@ if ($IS_HLX_PATH) {
     redirect_uri: window.location.href,
     isSignedIn: false,
     onError: function (error) {
-      console.log(error);
+      console.error(error);
     },
     onReady: function (ims) {
       if (window.adobeIMSMethods.isSignedIn()) {
@@ -124,7 +128,7 @@ if ($IS_HLX_PATH) {
     redirect_uri: window.location.href,
     isSignedIn: false,
     onError: function (error) {
-      console.log(error);
+      console.error(error);
     },
     onReady: function (ims) {
       if (window.adobeIMSMethods.isSignedIn()) {
@@ -155,7 +159,7 @@ if ($IS_HLX_PATH) {
     redirect_uri: window.location.href,
     isSignedIn: false,
     onError: function (error) {
-      console.log(error);
+      console.error(error);
     },
     onReady: function (ims) {
       if (window.adobeIMSMethods.isSignedIn()) {
@@ -1203,9 +1207,9 @@ function decorateSearchIframeContainer($header) {
     const renderedFrame = $searchIframeContainer.firstChild;
 
     const searchFrameOnLoad = () => {
-      renderedFrame.contentWindow.postMessage(JSON.stringify({ localProduct: 'Adobe Developer App Builder' }), '*');
+      renderedFrame.contentWindow.postMessage(JSON.stringify({ localPathName: window.location.pathname }), '*');
 
-      if ($SEARCH_PRODUCT_RECEIVED !== 'Adobe Developer App Builder') {
+      if ($SEARCH_PATH_NAME_CHECK !== window.location.pathname) {
         window.setTimeout(searchFrameOnLoad, 100);
         return;
       }

--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -72,7 +72,7 @@ window.addEventListener('message', function (e) {
   if (e.origin !== expectedOrigin) return;
 
   try {
-    const message = JSON.parse(e.data);
+    const message = typeof e.data === "string" ? JSON.parse(e.data) : e.data;
     if (message.query) {
       setQueryStringParameter('query', message.query);
       setQueryStringParameter('keywords', message.keywords);
@@ -1206,14 +1206,15 @@ function decorateSearchIframeContainer($header) {
     $searchIframeContainer.appendChild(searchFrame);
     const renderedFrame = $searchIframeContainer.firstChild;
 
-    const searchFrameOnLoad = () => {
+    const searchFramePostPathName = () => {
       renderedFrame.contentWindow.postMessage(JSON.stringify({ localPathName: window.location.pathname }), '*');
-
       if ($SEARCH_PATH_NAME_CHECK !== window.location.pathname) {
         window.setTimeout(searchFrameOnLoad, 100);
         return;
       }
+    }
 
+    const searchFrameOnLoad = () => {
       const queryString = getQueryString();
       if (queryString) {
         $searchIframeContainer.style.visibility = 'visible';
@@ -1245,6 +1246,7 @@ function decorateSearchIframeContainer($header) {
       // Check if loading is complete
       if (iframeDoc.readyState === 'complete') {
         renderedFrame.onload = () => {
+          searchFramePostPathName();
           searchFrameOnLoad();
         };
         // The loading is complete, call the function we want executed once the iframe is loaded

--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -1209,6 +1209,7 @@ function decorateSearchIframeContainer($header) {
     const searchFramePostPathName = () => {
       renderedFrame.contentWindow.postMessage(JSON.stringify({ localPathName: window.location.pathname }), '*');
       if ($SEARCH_PATH_NAME_CHECK !== window.location.pathname) {
+        console.log("sending message again");
         window.setTimeout(searchFrameOnLoad, 100);
         return;
       }
@@ -1221,6 +1222,7 @@ function decorateSearchIframeContainer($header) {
       }
 
       $header.querySelectorAll('button.nav-dropdown-search').forEach(($button) => {
+        console.log($button);
         $button.style.visibility = "visible";
 
         $button.addEventListener('click', (evt) => {
@@ -1246,8 +1248,12 @@ function decorateSearchIframeContainer($header) {
       // Check if loading is complete
       if (iframeDoc.readyState === 'complete') {
         renderedFrame.onload = () => {
+          console.log("Pre pathname post");
           searchFramePostPathName();
+          console.log("Post pathname post");
           searchFrameOnLoad();
+          console.log("Post onload btn should work");
+
         };
         // The loading is complete, call the function we want executed once the iframe is loaded
         return;

--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -1186,9 +1186,7 @@ function isTopLevelNav(urlPathname) {
 }
 
 function decorateSearchIframeContainer($header) {
-  console.log("decorate");
   $header.querySelectorAll('div.nav-console-search-frame').forEach(($searchIframeContainer) => {
-    console.log("frame");
     const searchFrame = document.createElement('iframe');
     searchFrame.classList = "nav-search-iframe";
     searchFrame.src = setSearchFrameSource();
@@ -1197,15 +1195,11 @@ function decorateSearchIframeContainer($header) {
     let loaded = false;
 
     const searchFrameOnLoad = () => {
-      console.log("load");
       renderedFrame.contentWindow.postMessage(JSON.stringify({ localPathName: window.location.pathname }), '*');
       if ($SEARCH_PATH_NAME_CHECK !== window.location.pathname) {
-        console.log("sending message again");
         window.setTimeout(searchFrameOnLoad, 100);
         return;
       }
-
-      console.log(loaded);
 
       // Past this point we successfully passed the local pathname and received a confirmation from the iframe
       if (!loaded) {
@@ -1215,14 +1209,12 @@ function decorateSearchIframeContainer($header) {
         }
 
         $header.querySelectorAll('button.nav-dropdown-search').forEach(($button) => {
-          console.log("button event");
           $button.style.visibility = "visible";
 
           $button.addEventListener('click', (evt) => {
             if (!evt.currentTarget.classList.contains('is-open')) {
               $button.classList.add('is-open');
               $searchIframeContainer.style.visibility = 'visible';
-              console.log($searchIframeContainer);
               document.body.style.overflow = 'hidden';
             } else {
               $button.classList.remove('is-open');

--- a/hlx_statics/scripts.js
+++ b/hlx_statics/scripts.js
@@ -47,13 +47,11 @@ const setSearchFrameSource = () => {
 
 window.addEventListener('message', function (e) {
   const expectedOrigin = setExpectedOrigin();
-
   if (e.origin !== expectedOrigin) return;
 
   try{
-    if(typeof e !== 'object') {
+    if(typeof e == 'object') {
       const message = JSON.parse(e.data);
-
       setQueryStringParameter('query', message.query);
       setQueryStringParameter('keywords', message.keywords);
       setQueryStringParameter('index', message.index);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Improved on loading behaviour and included two way post message communication between iFrame and parent to provide the parent path name to the search app which can then select the appropriate local product based on the provided path name.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing url: 
https://local-search-frame-fix--adobe-io-website--adobe.hlx.page/
https://local-search-frame-fix--adobe-io-website--adobe.hlx.page/runtime/

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
