### PR TITLE
fixed issues with padding on sessions and set padding to zero for her…

### DIFF
--- a/hlx_statics/blocks/announcement/announcement.css
+++ b/hlx_statics/blocks/announcement/announcement.css
@@ -3,7 +3,6 @@ main div.announcement-container {
     background: var(--spectrum-global-color-gray-100);
     box-sizing: border-box;
     text-align: center;
-
     padding: var(--spectrum-global-dimension-size-400);
   }
 

--- a/hlx_statics/blocks/announcement/announcement.css
+++ b/hlx_statics/blocks/announcement/announcement.css
@@ -3,8 +3,12 @@ main div.announcement-container {
     background: var(--spectrum-global-color-gray-100);
     box-sizing: border-box;
     text-align: center;
-    height: calc(var(--spectrum-global-dimension-size-2000) + var(--spectrum-global-dimension-size-125));
+
     padding: var(--spectrum-global-dimension-size-400);
+  }
+
+  main div.section.video-enabled.announcement-container{
+    height: calc(var(--spectrum-global-dimension-size-2000) + var(--spectrum-global-dimension-size-125));  
   }
 
   @media screen and (max-width: 1280px) {

--- a/hlx_statics/blocks/announcement/announcement.js
+++ b/hlx_statics/blocks/announcement/announcement.js
@@ -49,3 +49,4 @@ export default async function decorate(block) {
   block
   calculateOverlapping(block);
 }
+

--- a/hlx_statics/blocks/hero/hero.css
+++ b/hlx_statics/blocks/hero/hero.css
@@ -6,6 +6,10 @@ main div.hero {
     justify-content: center;
   }
   
+  main div.hero-container {
+    padding: 0;
+  }
+  
   @media screen and (max-width: 1280px) {
     main div.hero {
       height: auto;

--- a/hlx_statics/blocks/summary/summary.css
+++ b/hlx_statics/blocks/summary/summary.css
@@ -2,6 +2,7 @@ main div.summary-container {
   background: var(--spectrum-global-color-gray-50);
   background-position: center;
   background-size: cover;
+  padding: 0;
 }
 
 main div.summary {

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -51,6 +51,10 @@ img {
   font-family: "adobe-clean",sans-serif;
 }
 
+main .section {
+  padding: var(--spectrum-global-dimension-size-400) 0;
+}
+
 /* progressive section appearance */
 main .section[data-section-status='loading'],
 main .section[data-section-status='initialized'] {


### PR DESCRIPTION
…o and summary blocks

<!--- Provide a general summary of your changes in the Title above -->

## Description
The padding is set to all of the sections except for hero and summary block where they are set to zero

<!--- Describe your changes in detail -->

## Related Issue

Issue #64 should be resolved with this PR

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

You can test the solutions here:
https://64-fixing-padding--adobe-io-website--adobe.hlx.page/photoshop/api/pricing-new
And here
https://64-fixing-padding--adobe-io-website--adobe.hlx.page/photoshop/index-new

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
