### PR TITLE
Migrate Carousel content block from Gatsby to Franklin

### DIFF
--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -1,0 +1,9 @@
+main div.carousel .img-size {
+    width: 50%;
+    height: auto;
+}
+
+main div.carousel .carousel-format {
+    display: flex;
+    flex-direction: row;
+}

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -4,18 +4,15 @@ main div.carousel .img-size {
 }
 
 main div.carousel {
-    width: var(--spectrum-global-dimension-static-grid-fixed-max-width);    margin: auto;
-    background-color: aqua;
+    width: var(--spectrum-global-dimension-static-grid-fixed-max-width);    
+    margin: auto;
+    /* background-color: aqua; */
 }
 
 main div.carousel .carousel-heading {
-    margin-top: 0 !important;
+    margin-top: 1 !important;
     margin-bottom: var(--spectrum-global-dimension-size-100) !important;
   }
-
-main div.carousel > div {
-    padding: var(--spectrum-global-dimension-size-1000) 0; 
-}
 
 main div.carousel .carousel-container {
     display: flex;
@@ -57,8 +54,10 @@ main .carousel .slides-container {
     width: 100%;
     display: flex;
     list-style: none;
-    margin: 0;
+    margin: 1;
     padding: 0;
+    margin-bottom: 1;
+    margin-top: 1;
     overflow: scroll;
     scroll-behavior: smooth;
 }
@@ -75,15 +74,15 @@ main .carousel .slide-arrow {
     top: 0;
     bottom: 0;
     margin: auto;
+    background-color: transparent;
     height: 4rem;
-    background-color: white;
     border: none;
     width: 2rem;
-    font-size: 3rem;
-    padding: 0;
+    font-size: 5rem;
+    color: blue;
     cursor: pointer;
     opacity: 0.5;
-    transition: opacity 100ms;
+    transition: opacity 100ms;  
 }
 
 main .carousel .slide-arrow:hover,
@@ -92,13 +91,19 @@ main .carousel .slide-arrow:focus {
 }
 
 #slide-arrow-previous {
-    left: 0;
-    padding-left: 0.25rem;
-    border-radius: 0 2rem 2rem 0;
+    left: 0%;
 }
 
 #slide-arrow-forward {
-    right: 0;
-    padding-left: 0.75rem;
-    border-radius: 2rem 0 0 2rem;
+    right: 0%;
+}
+
+main .carousel .slides-container {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none;  /* Internet Explorer 10+ */
+}
+/* WebKit */
+main .carousel .slides-container::-webkit-scrollbar { 
+    width: 0;
+    height: 0;
 }

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -8,13 +8,18 @@ main div.carousel {
     background-color: aqua;
 }
 
+main div.carousel .carousel-heading {
+    margin-top: 0 !important;
+    margin-bottom: var(--spectrum-global-dimension-size-100) !important;
+  }
+
 main div.carousel > div {
     padding: var(--spectrum-global-dimension-size-1000) 0; 
 }
 
 main div.carousel .carousel-container {
     display: flex;
-    flex-direction: row;
+    flex-direction: row-reverse;
     justify-content: center;
     align-content: space-between;
 }
@@ -36,6 +41,6 @@ main div.carousel .right-container {
 main .carousel .carousel-button-container {
     display: flex;
     flex-direction: row !important;
-    margin-top: var(--spectrum-global-dimension-size-300);
+    margin-top: var(--spectrum-global-dimension-size-100);
     gap: var(--spectrum-global-dimension-size-200);
-  }
+}

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -44,3 +44,61 @@ main .carousel .carousel-button-container {
     margin-top: var(--spectrum-global-dimension-size-100);
     gap: var(--spectrum-global-dimension-size-200);
 }
+
+
+main .carousel .slider-wrapper {
+    margin: 1rem;
+    position: relative;
+    overflow: hidden;
+}
+
+main .carousel .slides-container {
+    /* height: calc(100vh - 2rem); */
+    width: 100%;
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow: scroll;
+    scroll-behavior: smooth;
+}
+
+main .carousel .slide {
+    width: 100%;
+    height: 100%;
+    flex: 1 0 100%;
+}
+
+main .carousel .slide-arrow {
+    position: absolute;
+    display: flex;
+    top: 0;
+    bottom: 0;
+    margin: auto;
+    height: 4rem;
+    background-color: white;
+    border: none;
+    width: 2rem;
+    font-size: 3rem;
+    padding: 0;
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 100ms;
+}
+
+main .carousel .slide-arrow:hover,
+main .carousel .slide-arrow:focus {
+    opacity: 1;
+}
+
+#slide-arrow-previous {
+    left: 0;
+    padding-left: 0.25rem;
+    border-radius: 0 2rem 2rem 0;
+}
+
+#slide-arrow-forward {
+    right: 0;
+    padding-left: 0.75rem;
+    border-radius: 2rem 0 0 2rem;
+}

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -4,9 +4,8 @@ main div.carousel .img-size {
 }
 
 main div.carousel {
-    width: var(--spectrum-global-dimension-static-grid-fixed-max-width);    
+    width: var(--spectrum-global-dimension-static-grid-fixed-max-width);
     margin: auto;
-    /* background-color: aqua; */
 }
 
 main div.carousel .block-container {
@@ -14,6 +13,7 @@ main div.carousel .block-container {
     flex-direction: row ;
     justify-content: center;
     align-content: space-between;
+    position: relative;
 }
 
 main div.carousel .carousel-heading {
@@ -55,6 +55,7 @@ main div.carousel .slider-wrapper {
     overflow: hidden;
     transition-property: transform;
     box-sizing: content-box;
+    align-items: center;
 }
 
 main div.carousel .slides-container {

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -5,7 +5,7 @@ picture {
 }
 
 picture img {
-    object-fit: cover; 
+    object-fit: cover;
     height: auto;
     width: 100%;
 }
@@ -48,6 +48,9 @@ main div.carousel .left-container {
 }
 
 main div.carousel .right-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     flex: 0 1 50%;
     min-height: 100%;
     max-width: 50%;
@@ -70,7 +73,6 @@ main div.carousel .slider-wrapper {
 }
 
 main div.carousel .slides-container {
-    /* height: calc(100vh - 2rem); */
     width: 100%;
     display: flex;
     list-style: none;

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -54,7 +54,7 @@ main div.carousel .right-container {
     flex: 0 1 50%;
     min-height: 100%;
     max-width: 50%;
-    padding: 0 var(--spectrum-global-dimension-size-100);
+    padding: 0 var(--spectrum-global-dimension-size-400);
 }
 
 main div.carousel .carousel-button-container {
@@ -97,7 +97,6 @@ main div.carousel .slide-arrow {
     font-size: 5rem;
     color: #b3cef7;
     cursor: pointer;
-    /* transition: opacity 100ms;    */
 }
 
 main .carousel .slide-arrow:hover,

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -31,5 +31,11 @@ main div.carousel .right-container {
     min-height: 100%;
     max-width: 50%;
     padding: 0 var(--spectrum-global-dimension-size-100);
-
 }
+
+main .carousel .carousel-button-container {
+    display: flex;
+    flex-direction: row !important;
+    margin-top: var(--spectrum-global-dimension-size-300);
+    gap: var(--spectrum-global-dimension-size-200);
+  }

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -125,7 +125,7 @@ main div.carousel .carousel-circle {
     background-color: #c6c6c6;
     border: none;
     border-radius: 100%;
-    width: auto;
+    width: 12px;
     height: 12px;
     margin: 4px 2px;
     cursor: pointer;

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -1,9 +1,35 @@
 main div.carousel .img-size {
-    width: 50%;
-    height: auto;
+    object-fit: cover;
+    width: 100% !important;
 }
 
-main div.carousel .carousel-format {
+main div.carousel {
+    width: var(--spectrum-global-dimension-static-grid-fixed-max-width);    margin: auto;
+    background-color: aqua;
+}
+
+main div.carousel > div {
+    padding: var(--spectrum-global-dimension-size-1000) 0; 
+}
+
+main div.carousel .carousel-container {
     display: flex;
     flex-direction: row;
+    justify-content: center;
+    align-content: space-between;
+}
+
+main div.carousel .left-container {
+    flex: 0 1 50%;
+    min-height: 100%;
+    max-width: 50%;
+    padding: 0 var(--spectrum-global-dimension-size-100);
+}
+
+main div.carousel .right-container {
+    flex: 0 1 50%;
+    min-height: 100%;
+    max-width: 50%;
+    padding: 0 var(--spectrum-global-dimension-size-100);
+
 }

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -1,6 +1,18 @@
-main div.carousel .img-size {
-    object-fit: cover;
-    width: 100% !important;
+picture {
+    width: 100%;
+    height: 100%;
+    display: flex;
+}
+
+picture img {
+    object-fit: cover; 
+    height: auto;
+    width: 100%;
+}
+
+main div.carousel .image-container {
+    height: 300px;
+    max-width: 602px;
 }
 
 main div.carousel {
@@ -49,7 +61,6 @@ main div.carousel .carousel-button-container {
     gap: var(--spectrum-global-dimension-size-200);
 }
 
-
 main div.carousel .slider-wrapper {
     position: relative;
     overflow: hidden;
@@ -82,21 +93,21 @@ main div.carousel .slide-arrow {
     background-color: transparent; 
     border: none;
     font-size: 5rem;
-    color: blue;
+    color: #b3cef7;
     cursor: pointer;
-    opacity: 0.5;
     /* transition: opacity 100ms;    */
 }
 
 main .carousel .slide-arrow:hover,
 main .carousel .slide-arrow:focus {
-    opacity: 1;
+    color: #007aff;
 }
 
 main div.carousel .slides-container {
     scrollbar-width: none; /* Firefox */
     -ms-overflow-style: none;  /* Internet Explorer 10+ */
 }
+
 /* WebKit */
 main div.carousel .slides-container::-webkit-scrollbar { 
     width: 0;
@@ -113,13 +124,13 @@ main div.carousel .carousel-circle-div {
 main div.carousel .carousel-circle {
     background-color: #c6c6c6;
     border: none;
-    border-radius: 50%;
-    width: 10px;
-    height: 10px;
+    border-radius: 100%;
+    width: auto;
+    height: 12px;
     margin: 4px 2px;
     cursor: pointer;
 }
 
 main div.carousel .carousel-circle-selected {
     background-color: #007aff !important;
-  }
+}

--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -9,6 +9,13 @@ main div.carousel {
     /* background-color: aqua; */
 }
 
+main div.carousel .block-container {
+    display: flex;
+    flex-direction: row ;
+    justify-content: center;
+    align-content: space-between;
+}
+
 main div.carousel .carousel-heading {
     margin-top: 1 !important;
     margin-bottom: var(--spectrum-global-dimension-size-100) !important;
@@ -35,7 +42,7 @@ main div.carousel .right-container {
     padding: 0 var(--spectrum-global-dimension-size-100);
 }
 
-main .carousel .carousel-button-container {
+main div.carousel .carousel-button-container {
     display: flex;
     flex-direction: row !important;
     margin-top: var(--spectrum-global-dimension-size-100);
@@ -43,13 +50,14 @@ main .carousel .carousel-button-container {
 }
 
 
-main .carousel .slider-wrapper {
-    margin: 1rem;
+main div.carousel .slider-wrapper {
     position: relative;
     overflow: hidden;
+    transition-property: transform;
+    box-sizing: content-box;
 }
 
-main .carousel .slides-container {
+main div.carousel .slides-container {
     /* height: calc(100vh - 2rem); */
     width: 100%;
     display: flex;
@@ -58,31 +66,25 @@ main .carousel .slides-container {
     padding: 0;
     margin-bottom: 1;
     margin-top: 1;
-    overflow: scroll;
+    overflow: hidden;
     scroll-behavior: smooth;
 }
 
-main .carousel .slide {
+main div.carousel .slide {
     width: 100%;
     height: 100%;
     flex: 1 0 100%;
 }
 
-main .carousel .slide-arrow {
-    position: absolute;
-    display: flex;
-    top: 0;
-    bottom: 0;
+main div.carousel .slide-arrow {
     margin: auto;
-    background-color: transparent;
-    height: 4rem;
+    background-color: transparent; 
     border: none;
-    width: 2rem;
     font-size: 5rem;
     color: blue;
     cursor: pointer;
     opacity: 0.5;
-    transition: opacity 100ms;  
+    /* transition: opacity 100ms;    */
 }
 
 main .carousel .slide-arrow:hover,
@@ -90,20 +92,33 @@ main .carousel .slide-arrow:focus {
     opacity: 1;
 }
 
-#slide-arrow-previous {
-    left: 0%;
-}
-
-#slide-arrow-forward {
-    right: 0%;
-}
-
-main .carousel .slides-container {
+main div.carousel .slides-container {
     scrollbar-width: none; /* Firefox */
     -ms-overflow-style: none;  /* Internet Explorer 10+ */
 }
 /* WebKit */
-main .carousel .slides-container::-webkit-scrollbar { 
+main div.carousel .slides-container::-webkit-scrollbar { 
     width: 0;
     height: 0;
 }
+
+main div.carousel .carousel-circle-div {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
+
+main div.carousel .carousel-circle {
+    background-color: #c6c6c6;
+    border: none;
+    border-radius: 50%;
+    width: 10px;
+    height: 10px;
+    margin: 4px 2px;
+    cursor: pointer;
+}
+
+main div.carousel .carousel-circle-selected {
+    background-color: #007aff !important;
+  }

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -95,7 +95,7 @@ export default async function decorate(block) {
         }else{
             let flex_div = block.querySelector("[id=right-flex-div-" + CSS.escape(p.parentElement.id)+ "]");
             flex_div.setAttribute('class', 'right-container');
-            p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
+            p.classList.add('spectrum-Body', 'spectrum-Body--sizeM');
             flex_div.insertBefore(p, button_div);
         }
     };
@@ -103,7 +103,7 @@ export default async function decorate(block) {
 
   //slide functionality with arrow buttons
   const slidesContainer = block.querySelector(".slides-container");
-  const slide = document.querySelector(".slide");
+  const slide = block.querySelector(".slide");
   const prevButton = block.querySelector(".slide-arrow-previous");
   const nextButton = block.querySelector(".slide-arrow-forward");
 
@@ -206,18 +206,18 @@ export default async function decorate(block) {
     if(!isPaused){
         // console.log("not paused");
         advanceSlide();
-        setTimeout(slideTimer, 3000);
+        setTimeout(slideTimer, 9000);
     }else{
         // console.log("paused");
         clearTimeout(timer);
         //after set amount of time automatic scrolling can commence
-        setTimeout(() => {isPaused = false;}, 4000);
-        setTimeout(slideTimer, 3000);
+        setTimeout(() => {isPaused = false;}, 18000);
+        setTimeout(slideTimer, 9000);
     };   
   };
 
-  const timer = setTimeout(slideTimer, 4000);
-  timer;
+//   const timer = setTimeout(slideTimer, 9000);
+//   timer;
 
 }
 

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -172,4 +172,41 @@ export default async function decorate(block) {
         button.classList.add('carousel-circle-selected');
     });
   });
+
+  //automatic scrolling
+  function advanceSlide() {
+    //get new slide number
+    let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
+    let slide_selected_num = parseInt(slide_selected.id);
+    let new_slide_num = slide_selected_num+1;
+    let new_slide;
+    if(new_slide_num === count){ //at last slide - can't go forward more
+        new_slide = document.getElementById(1);
+        //change color of circle
+        slide_selected.classList.remove('carousel-circle-selected')
+        new_slide.classList.add('carousel-circle-selected');
+        //slide over to new slide - needs to start over
+        const difference = count - 1 - 1;
+        const slideWidth = slide.clientWidth;
+        slidesContainer.scrollLeft -= (difference*slideWidth);
+    }else{
+        new_slide = document.getElementById(new_slide_num);
+        //change color of circle
+        slide_selected.classList.remove('carousel-circle-selected')
+        new_slide.classList.add('carousel-circle-selected');
+        //slide over to new slide
+        const slideWidth = slide.clientWidth;
+        slidesContainer.scrollLeft += slideWidth;
+    };  
+  };
+  
+  function slideTimer() {
+    advanceSlide();
+    setTimeout(slideTimer, 3000)
+  }
+  
+  setTimeout(slideTimer, 3000)
 }
+
+  
+

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -5,7 +5,6 @@ import { createTag, decorateButtons, removeEmptyPTags} from '../../scripts/lib-a
  * @param {Element} block The carousel block element
  */
 export default async function decorate(block) {
-  decorateButtons(block);
   removeEmptyPTags(block);
 
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
@@ -19,6 +18,9 @@ export default async function decorate(block) {
     let flex_div = createTag('div', { id: 'left-flex-div-'+h.id});
     h.parentElement.append(flex_div);
     flex_div.append(h);
+
+    let button_div = createTag('div', { id: 'button-div-'+h.id});
+    h.parentElement.append(button_div);
 
   });
 
@@ -38,11 +40,24 @@ export default async function decorate(block) {
     if(p.id === "IMAGE"){
         p.classList.add('spectrum-Body', 'spectrum-Body--sizeS');
     }else{
-        let flex_div = document.getElementById('left-flex-div-' + p.parentElement.id); 
-        flex_div.setAttribute('class', 'left-container');
-        p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-        flex_div.append(p);
-    }
+        let button_div = document.getElementById('button-div-' + p.parentElement.id); 
+        if(p.classList.contains('button-container')){
+            //add buttons to div
+            button_div.classList.add('carousel-button-container');
+            button_div.append(p);
+        }else{
+            let flex_div = document.getElementById('left-flex-div-' + p.parentElement.id); 
+            flex_div.setAttribute('class', 'left-container');
+            p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
+            flex_div.insertBefore(p, button_div);
+        }
+        
+
+        
+    };
   });
+
+  decorateButtons(block);
+
 }
 

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -57,7 +57,7 @@ export default async function decorate(block) {
 
     //create li tag to hold carousel slide (div)
     let carousel_li = createTag('li', {class: 'slide'});
-    carousel_li.setAttribute('id', h.id);
+    // carousel_li.setAttribute('id', "li-"+h.id);
     carousel_ul.append(carousel_li);
     carousel_li.append(h.parentElement);
 
@@ -195,13 +195,14 @@ export default async function decorate(block) {
         const slideWidth = slide.clientWidth;
         slidesContainer.scrollLeft -= (difference*slideWidth);
     }else{
-        new_slide = document.getElementById(new_slide_num);
-        //change color of circle
-        slide_selected.classList.remove('carousel-circle-selected')
-        new_slide.classList.add('carousel-circle-selected');
         //slide over to new slide
         const slideWidth = slide.clientWidth;
         slidesContainer.scrollLeft += slideWidth;
+        new_slide = document.getElementById(new_slide_num);
+        //change color of circle
+        new_slide.classList.add('carousel-circle-selected');
+        slide_selected.classList.remove('carousel-circle-selected')
+        
     };  
   };
   
@@ -214,14 +215,12 @@ export default async function decorate(block) {
         console.log("paused");
         clearTimeout(timer);
         //after set amount of time automatic scrolling can commence
-        setTimeout(() => {
-            isPaused = false;
-        }, 4000);
+        setTimeout(() => {isPaused = false;}, 4000);
         setTimeout(slideTimer, 3000);
     };   
   };
 
-  const timer = setTimeout(slideTimer(), 3000);
+  const timer = setTimeout(slideTimer, 4000);
   timer;
 
 }

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -1,5 +1,4 @@
-import { createTag, decorateButtons } from '../../scripts/lib-adobeio.js';
-
+import { createTag, decorateButtons, removeEmptyPTags} from '../../scripts/lib-adobeio.js';
 
 /**
  * decorates the carousel
@@ -7,43 +6,43 @@ import { createTag, decorateButtons } from '../../scripts/lib-adobeio.js';
  */
 export default async function decorate(block) {
   decorateButtons(block);
+  removeEmptyPTags(block);
 
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
-    //add everything but image to a div
-    const flex_div = createTag('div', { id: 'flex_div' });
+    //create flex display
+    h.parentElement.classList.add('carousel-container');
+    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL');
+
+    h.parentElement.setAttribute('id', h.id);
+
+    //add everything but image to the left div
+    let flex_div = createTag('div', { id: 'left-flex-div-'+h.id});
     h.parentElement.append(flex_div);
     flex_div.append(h);
 
   });
 
-  const flex_div = document.getElementById('flex_div');
-
-  block.querySelectorAll('p').forEach(function (p){
-    p.childNodes.forEach(function (child) {
-        // console.log(child.nodeName);
-        if(child.nodeName === 'PICTURE'){
-            
-            p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-        } else {
-            console.log(child.nodeName);
-            flex_div.appendChild(p);
-        };
-    });
-    
-  });
-
-  block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
-    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL');
-    //make a flex box - row
-    h.parentElement.parentElement.classList.add('carousel-format');
-  });
-
   block.querySelectorAll('img').forEach((img) => {
     img.classList.add('img-size');
+    img.parentElement.parentElement.setAttribute('id', 'IMAGE');
+
+    //add image to right div
+    let flex_div = createTag('div', { id: 'right-flex-div-'+img.parentElement.parentElement.parentElement.id});
+    img.parentElement.parentElement.parentElement.append(flex_div);
+    flex_div.append(img.parentElement.parentElement);
+    flex_div.classList.add('right-container');
   });
-  
 
-
-  
+  block.querySelectorAll('p').forEach(function (p){
+    //add everything but image to the left div
+    if(p.id === "IMAGE"){
+        p.classList.add('spectrum-Body', 'spectrum-Body--sizeS');
+    }else{
+        let flex_div = document.getElementById('left-flex-div-' + p.parentElement.id); 
+        flex_div.setAttribute('class', 'left-container');
+        p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
+        flex_div.append(p);
+    }
+  });
 }
 

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -10,16 +10,12 @@ export default async function decorate(block) {
   const carousel_block_child = createTag('div', {class: 'block-container'});
   block.append(carousel_block_child);
 
-  //create div with circle progess
   const carousel_block_circle = createTag('div', {class: 'carousel-circle-div'});
-//   carousel_block_circle.classList.add('carousel-circle-div');
   block.append(carousel_block_circle);
 
-  //create section tag for animation
   const carousel_section = createTag('section', {class: 'slider-wrapper'});
   carousel_block_child.append(carousel_section);
 
-  //add slide arrow buttons
   const arrow_button_previous = createTag('button', {class: 'slide-arrow'});
   arrow_button_previous.classList.add('slide-arrow-previous');
   arrow_button_previous.innerHTML = '&#8249;'
@@ -27,22 +23,16 @@ export default async function decorate(block) {
   arrow_button_forward.classList.add('slide-arrow-forward');
   arrow_button_forward.innerHTML = '&#8250;'
 
-  //add ul tag to contain carousel slides
   const carousel_ul = createTag('ul', {class: 'slides-container'});
   carousel_section.append(carousel_ul);
-
+  
   //add a count to keep track of which slide is showing
   let count = 1;
 
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
-    //create flex display
     h.parentElement.classList.add('carousel-container');
-
-    //add section tag and replace the div with it
     h.parentElement.parentElement.replaceWith(carousel_block_child);
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL', 'carousel-heading');
-
-    //name div for convenience and add divs to section tag
     h.parentElement.setAttribute('id', h.id);
 
     //add circle for every slide
@@ -52,7 +42,6 @@ export default async function decorate(block) {
     div_slide_circle.append(circle_button);
     count += 1;
 
-    //create li tag to hold carousel slide (div)
     let carousel_li = createTag('li', {class: 'slide'});
     carousel_ul.append(carousel_li);
     carousel_li.append(h.parentElement);
@@ -62,19 +51,16 @@ export default async function decorate(block) {
     h.parentElement.append(flex_div);
     flex_div.append(h);
 
-    //add buttons to a button div so they can be next to each other
     let button_div = createTag('div', { id: 'button-div-'+h.id});
     h.parentElement.append(button_div);
 
   });
 
-  //add arrows and slide in proper order
   carousel_block_child.insertBefore(arrow_button_previous, carousel_section);
   carousel_block_child.append(arrow_button_forward);
 
   //add id to image and add image to left div
   block.querySelectorAll('img').forEach((img) => {
-    //to identify image later
     img.parentElement.parentElement.classList.add('IMAGE');
     //add image to left div
     let flex_div = createTag('div', { id: 'left-flex-div-'+img.parentElement.parentElement.parentElement.id});
@@ -88,13 +74,12 @@ export default async function decorate(block) {
     if(p.classList.contains("IMAGE") ){
         p.classList.add('image-container');
     }else{
-        let button_div = block.querySelector("[id=button-div-" + CSS.escape(p.parentElement.id)+ "]");
+        let button_div = block.querySelector("[id=button-div-" + p.parentElement.id + "]");
         if(p.classList.contains('button-container')){
-            //add buttons to div
             button_div.classList.add('carousel-button-container');
             button_div.append(p);
         }else{
-            let flex_div = block.querySelector("[id=right-flex-div-" + CSS.escape(p.parentElement.id)+ "]");
+            let flex_div = block.querySelector("[id=right-flex-div-" + p.parentElement.id + "]");
             flex_div.setAttribute('class', 'right-container');
             p.classList.add('spectrum-Body', 'spectrum-Body--sizeM');
             flex_div.insertBefore(p, button_div);
@@ -113,41 +98,35 @@ export default async function decorate(block) {
   
   nextButton.addEventListener("click", () => {
     isPaused = true;
-    //get new slide number
     let slide_selected = block.querySelector(".carousel-circle-selected");
     let slide_selected_num = parseInt(slide_selected.id);
     let new_slide_num = slide_selected_num+1;
     let new_slide;
-    if(new_slide_num === count){ //at last slide - can't go forward more
-        
-    } else {
-        //slide over to new slide
-        const slideDx = slidesContainer.clientLeft + (slide.clientWidth * slide_selected_num);
-        slidesContainer.scrollLeft = slideDx;
-        //change color of circle
-        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
-        slide_selected.classList.remove('carousel-circle-selected')
-        new_slide.classList.add('carousel-circle-selected');
+    if(new_slide_num !== count){ //at last slide - can't go forward more
+      //slide over to new slide
+      const slideDx = slidesContainer.clientLeft + (slide.clientWidth * slide_selected_num);
+      slidesContainer.scrollLeft = slideDx;
+      //change color of circle
+      new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
+      slide_selected.classList.remove('carousel-circle-selected')
+      new_slide.classList.add('carousel-circle-selected'); 
     };  
   });
 
   prevButton.addEventListener("click", () => {
     isPaused = true;
-    //get new slide number
     let slide_selected = block.querySelector(".carousel-circle-selected"); //should only be one in the block
     let slide_selected_num = parseInt(slide_selected.id);
     let new_slide_num = slide_selected_num-1;
     let new_slide;
-    if(new_slide_num === 0){ //at first slide - can't go back more
-
-    }else{
-      //slide over to new slide
-      const slideDx = (new_slide_num-1) * slide.clientWidth;
-      slidesContainer.scrollLeft = slideDx;
-      //change color of circle
-      new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
-      slide_selected.classList.remove('carousel-circle-selected');
-      new_slide.classList.add('carousel-circle-selected');
+    if(new_slide_num !== 0){ //at first slide - can't go back more
+        //slide over to new slide
+        const slideDx = (new_slide_num-1) * slide.clientWidth;
+        slidesContainer.scrollLeft = slideDx;
+        //change color of circle
+        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
+        slide_selected.classList.remove('carousel-circle-selected');
+        new_slide.classList.add('carousel-circle-selected');
     };
   });
 
@@ -171,8 +150,7 @@ export default async function decorate(block) {
 
   //automatic scrolling
   function advanceSlide() {
-    //get new slide number
-    let slide_selected = block.querySelector('.carousel-circle-selected'); //should only be one in the block
+    let slide_selected = block.querySelector('.carousel-circle-selected'); 
     let slide_selected_num = parseInt(slide_selected.id);
     let new_slide_num = slide_selected_num+1;
     let new_slide;
@@ -212,6 +190,3 @@ export default async function decorate(block) {
   timer;
 
 }
-
-  
-

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -20,8 +20,8 @@ export default async function decorate(block) {
   const arrow_button_forward = createTag('button', {class: 'slide-arrow'});
   arrow_button_forward.setAttribute('id', 'slide-arrow-forward');
   arrow_button_forward.innerHTML = '&#8250;'
-  carousel_section.append(arrow_button_previous);
-  carousel_section.append(arrow_button_forward);
+  carousel_block.append(arrow_button_previous);
+  carousel_block.append(arrow_button_forward);
 
   //add ul tag to contain carousel slides
   const carousel_ul = createTag('ul', {class: 'slides-container'});

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -1,5 +1,4 @@
 import { createTag, decorateButtons, removeEmptyPTags} from '../../scripts/lib-adobeio.js';
-
 /**
  * decorates the carousel
  * @param {Element} block The carousel block element
@@ -10,8 +9,16 @@ export default async function decorate(block) {
 
   //create section tag for animation
   const carousel_block = document.getElementsByClassName('carousel block')[0];
+  const carousel_block_child = createTag('div', {class: 'block-container'});
+  carousel_block.append(carousel_block_child);
+
+  //create div with circle progess
+  const carousel_block_circle = createTag('div', {id: 'carousel-circles'});
+  carousel_block_circle.setAttribute('class', 'carousel-circle-div');
+  carousel_block.append(carousel_block_circle);
+
   const carousel_section = createTag('section', {class: 'slider-wrapper'});
-  carousel_block.append(carousel_section);
+  carousel_block_child.append(carousel_section);
 
   //add slide arrow buttons
   const arrow_button_previous = createTag('button', {class: 'slide-arrow'});
@@ -20,23 +27,31 @@ export default async function decorate(block) {
   const arrow_button_forward = createTag('button', {class: 'slide-arrow'});
   arrow_button_forward.setAttribute('id', 'slide-arrow-forward');
   arrow_button_forward.innerHTML = '&#8250;'
-  carousel_section.append(arrow_button_previous);
-  carousel_section.append(arrow_button_forward);
 
   //add ul tag to contain carousel slides
   const carousel_ul = createTag('ul', {class: 'slides-container'});
   carousel_ul.setAttribute('id', 'slides-container');
   carousel_section.append(carousel_ul);
 
+  //add a count to keep track of which slide is showing
+  let count = 1;
+
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     //create flex display
     h.parentElement.classList.add('carousel-container');
     //add section tag for animation
-    h.parentElement.parentElement.replaceWith(carousel_section);
+    h.parentElement.parentElement.replaceWith(carousel_block_child);
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL', 'carousel-heading');
 
     //name div for convenience and add divs to section tag
     h.parentElement.setAttribute('id', h.id);
+
+    //add circle for every slide
+    let div_slide_circle = document.getElementById('carousel-circles');
+    let circle_button = createTag('button', {class: 'carousel-circle'});
+    circle_button.setAttribute('id', count);
+    div_slide_circle.append(circle_button);
+    count += 1;
 
     //create li tag to hold carousel slide (div)
     let carousel_li = createTag('li', {class: 'slide'});
@@ -53,6 +68,9 @@ export default async function decorate(block) {
     h.parentElement.append(button_div);
 
   });
+
+  carousel_block_child.insertBefore(arrow_button_previous, carousel_section);
+  carousel_block_child.append(arrow_button_forward);
 
   block.querySelectorAll('img').forEach((img) => {
     img.classList.add('img-size');
@@ -89,17 +107,53 @@ export default async function decorate(block) {
   const slide = document.querySelector(".slide");
   const prevButton = document.getElementById("slide-arrow-previous");
   const nextButton = document.getElementById("slide-arrow-forward");
-
+  
   nextButton.addEventListener("click", () => {
+    //change circle color 
+    let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
+    let slide_selected_id = slide_selected.id;
+    let new_slide = document.getElementById(parseInt(slide_selected_id)+1);
+    slide_selected.classList.remove('carousel-circle-selected')
+    new_slide.classList.add('carousel-circle-selected');
+    //slide over to new slide
     const slideWidth = slide.clientWidth;
-      slidesContainer.scrollLeft += slideWidth;
+    slidesContainer.scrollLeft += slideWidth;
   });
 
   prevButton.addEventListener("click", () => {
+    //change circle color 
+    let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
+    let slide_selected_id = slide_selected.id;
+    let new_slide = document.getElementById(parseInt(slide_selected_id)-1);
+    slide_selected.classList.remove('carousel-circle-selected')
+    new_slide.classList.add('carousel-circle-selected');
+    //slide over to new slide
     const slideWidth = slide.clientWidth;
     slidesContainer.scrollLeft -= slideWidth;
   });
+
+  //change color of circle button when clicked
+  const buttons = block.querySelectorAll('.carousel-circle');
+  buttons[0].classList.add('carousel-circle-selected'); //when reloading first slide should be selected
   
+  buttons.forEach((button, i) => {
+    button.addEventListener("click", () => {
+        let old_slide_num = document.getElementsByClassName('carousel-circle-selected')[0].id;
+        let new_slide_num = button.id;
+        let difference = new_slide_num - old_slide_num;
+        if(difference > 0){ //going forward
+            const slideWidth = slide.clientWidth;
+            slidesContainer.scrollLeft += (difference * slideWidth);
+        }else{ //going back
+            const slideWidth = slide.clientWidth;
+            slidesContainer.scrollLeft -= (-difference * slideWidth);
+        };
+        buttons.forEach((button) =>
+            button.classList.remove('carousel-circle-selected')
+        );
+        button.classList.add('carousel-circle-selected');
+    });
+  });
 
 }
 

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -8,12 +8,41 @@ export default async function decorate(block) {
   removeEmptyPTags(block);
   decorateButtons(block);
 
+  //create section tag for animation
+  const carousel_block = document.getElementsByClassName('carousel block')[0];
+  const carousel_section = createTag('section', {class: 'slider-wrapper'});
+  carousel_block.append(carousel_section);
+
+  //add slide arrow buttons
+  const arrow_button_previous = createTag('button', {class: 'slide-arrow'});
+  arrow_button_previous.setAttribute('id', 'slide-arrow-previous');
+  arrow_button_previous.innerHTML = '&#8249;'
+  const arrow_button_forward = createTag('button', {class: 'slide-arrow'});
+  arrow_button_forward.setAttribute('id', 'slide-arrow-forward');
+  arrow_button_forward.innerHTML = '&#8250;'
+  carousel_section.append(arrow_button_previous);
+  carousel_section.append(arrow_button_forward);
+
+  //add ul tag to contain carousel slides
+  const carousel_ul = createTag('ul', {class: 'slides-container'});
+  carousel_ul.setAttribute('id', 'slides-container');
+  carousel_section.append(carousel_ul);
+
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     //create flex display
     h.parentElement.classList.add('carousel-container');
+    //add section tag for animation
+    h.parentElement.parentElement.replaceWith(carousel_section);
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL', 'carousel-heading');
 
+    //name div for convenience and add divs to section tag
     h.parentElement.setAttribute('id', h.id);
+
+    //create li tag to hold carousel slide (div)
+    let carousel_li = createTag('li', {class: 'slide'});
+    carousel_li.setAttribute('id', h.id);
+    carousel_ul.append(carousel_li);
+    carousel_li.append(h.parentElement);
 
     //add everything but image to the left div
     let flex_div = createTag('div', { id: 'left-flex-div-'+h.id});
@@ -54,5 +83,23 @@ export default async function decorate(block) {
         }
     };
   });
+
+  //slide functionality with arrow buttons
+  const slidesContainer = document.getElementById("slides-container");
+  const slide = document.querySelector(".slide");
+  const prevButton = document.getElementById("slide-arrow-previous");
+  const nextButton = document.getElementById("slide-arrow-forward");
+
+  nextButton.addEventListener("click", () => {
+    const slideWidth = slide.clientWidth;
+      slidesContainer.scrollLeft += slideWidth;
+  });
+
+  prevButton.addEventListener("click", () => {
+    const slideWidth = slide.clientWidth;
+    slidesContainer.scrollLeft -= slideWidth;
+  });
+  
+
 }
 

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -7,7 +7,7 @@ export default async function decorate(block) {
   removeEmptyPTags(block);
   decorateButtons(block);
 
-  //create section tag for animation
+  //create a div in block for ease of use
   const carousel_block = document.getElementsByClassName('carousel block')[0];
   const carousel_block_child = createTag('div', {class: 'block-container'});
   carousel_block.append(carousel_block_child);
@@ -17,6 +17,7 @@ export default async function decorate(block) {
   carousel_block_circle.setAttribute('class', 'carousel-circle-div');
   carousel_block.append(carousel_block_circle);
 
+  //create section tag for animation
   const carousel_section = createTag('section', {class: 'slider-wrapper'});
   carousel_block_child.append(carousel_section);
 
@@ -39,7 +40,8 @@ export default async function decorate(block) {
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     //create flex display
     h.parentElement.classList.add('carousel-container');
-    //add section tag for animation
+
+    //add section tag and replace the div with it
     h.parentElement.parentElement.replaceWith(carousel_block_child);
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL', 'carousel-heading');
 
@@ -60,7 +62,7 @@ export default async function decorate(block) {
     carousel_li.append(h.parentElement);
 
     //add everything but image to the left div
-    let flex_div = createTag('div', { id: 'left-flex-div-'+h.id});
+    let flex_div = createTag('div', { id: 'right-flex-div-'+h.id});
     h.parentElement.append(flex_div);
     flex_div.append(h);
 
@@ -69,24 +71,25 @@ export default async function decorate(block) {
 
   });
 
+  //add arrows and slide in proper order
   carousel_block_child.insertBefore(arrow_button_previous, carousel_section);
   carousel_block_child.append(arrow_button_forward);
 
+  //add id to image and add image to left div
   block.querySelectorAll('img').forEach((img) => {
-    img.classList.add('img-size');
     img.parentElement.parentElement.setAttribute('id', 'IMAGE');
 
-    //add image to right div
-    let flex_div = createTag('div', { id: 'right-flex-div-'+img.parentElement.parentElement.parentElement.id});
+    //add image to left div
+    let flex_div = createTag('div', { id: 'left-flex-div-'+img.parentElement.parentElement.parentElement.id});
     img.parentElement.parentElement.parentElement.append(flex_div);
     flex_div.append(img.parentElement.parentElement);
-    flex_div.classList.add('right-container');
+    flex_div.classList.add('left-container');
   });
 
   block.querySelectorAll('p').forEach(function (p){
-    //add everything but image to the left div
+    //add everything but image to the right div
     if(p.id === "IMAGE"){
-        p.classList.add('spectrum-Body', 'spectrum-Body--sizeS');
+        p.classList.add('spectrum-Body', 'spectrum-Body--sizeS', 'image-container');
     }else{
         let button_div = document.getElementById('button-div-' + p.parentElement.id); 
         if(p.classList.contains('button-container')){
@@ -94,8 +97,8 @@ export default async function decorate(block) {
             button_div.classList.add('carousel-button-container');
             button_div.append(p);
         }else{
-            let flex_div = document.getElementById('left-flex-div-' + p.parentElement.id); 
-            flex_div.setAttribute('class', 'left-container');
+            let flex_div = document.getElementById('right-flex-div-' + p.parentElement.id); 
+            flex_div.setAttribute('class', 'right-container');
             p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
             flex_div.insertBefore(p, button_div);
         }
@@ -109,16 +112,16 @@ export default async function decorate(block) {
   const nextButton = document.getElementById("slide-arrow-forward");
   
   nextButton.addEventListener("click", () => {
-    //change circle color 
+    //get new slide number
     let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
     let slide_selected_num = parseInt(slide_selected.id);
     let new_slide_num = slide_selected_num+1;
     let new_slide;
-    console.log(new_slide_num);
     if(new_slide_num === count){ //at last slide - can't go forward more
         
     }else{
         new_slide = document.getElementById(new_slide_num);
+        //change color of circle
         slide_selected.classList.remove('carousel-circle-selected')
         new_slide.classList.add('carousel-circle-selected');
         //slide over to new slide
@@ -128,21 +131,17 @@ export default async function decorate(block) {
   });
 
   prevButton.addEventListener("click", () => {
-    //change circle color 
+    //get new slide number
     let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
     let slide_selected_num = parseInt(slide_selected.id);
     let new_slide_num = slide_selected_num-1;
     let new_slide;
-    console.log("previous");
-    console.log(slide_selected_num);
-
-    console.log(new_slide_num);
-
     if(new_slide_num === 0){ //at first slide - can't go back more
 
     }else{
-        slide_selected.classList.remove('carousel-circle-selected');
         new_slide = document.getElementById(new_slide_num);
+        //change color of circle
+        slide_selected.classList.remove('carousel-circle-selected');
         new_slide.classList.add('carousel-circle-selected');
         //slide over to new slide
         const slideWidth = slide.clientWidth;
@@ -166,12 +165,11 @@ export default async function decorate(block) {
             const slideWidth = slide.clientWidth;
             slidesContainer.scrollLeft -= (-difference * slideWidth);
         };
+        //change circle color
         buttons.forEach((button) =>
             button.classList.remove('carousel-circle-selected')
         );
         button.classList.add('carousel-circle-selected');
     });
   });
-
 }
-

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -110,8 +110,11 @@ export default async function decorate(block) {
   const slide = document.querySelector(".slide");
   const prevButton = document.getElementById("slide-arrow-previous");
   const nextButton = document.getElementById("slide-arrow-forward");
+
+  let isPaused = false;
   
   nextButton.addEventListener("click", () => {
+    isPaused = true;
     //get new slide number
     let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
     let slide_selected_num = parseInt(slide_selected.id);
@@ -131,6 +134,7 @@ export default async function decorate(block) {
   });
 
   prevButton.addEventListener("click", () => {
+    isPaused = true;
     //get new slide number
     let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
     let slide_selected_num = parseInt(slide_selected.id);
@@ -155,6 +159,7 @@ export default async function decorate(block) {
   
   buttons.forEach((button, i) => {
     button.addEventListener("click", () => {
+        isPaused = true;
         let old_slide_num = document.getElementsByClassName('carousel-circle-selected')[0].id;
         let new_slide_num = button.id;
         let difference = new_slide_num - old_slide_num;
@@ -201,11 +206,24 @@ export default async function decorate(block) {
   };
   
   function slideTimer() {
-    advanceSlide();
-    setTimeout(slideTimer, 3000)
-  }
-  
-  setTimeout(slideTimer, 3000)
+    if(!isPaused){
+        console.log("not paused");
+        advanceSlide();
+        setTimeout(slideTimer, 3000);
+    }else{
+        console.log("paused");
+        clearTimeout(timer);
+        //after set amount of time automatic scrolling can commence
+        setTimeout(() => {
+            isPaused = false;
+        }, 4000);
+        setTimeout(slideTimer, 3000);
+    };   
+  };
+
+  const timer = setTimeout(slideTimer(), 3000);
+  timer;
+
 }
 
   

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -1,0 +1,25 @@
+import { decorateButtons,rearrangeHeroPicture } from '../../scripts/lib-adobeio.js';
+
+
+/**
+ * decorates the carousel
+ * @param {Element} block The carousel block element
+ */
+export default async function decorate(block) {
+  decorateButtons(block);
+  block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
+    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL');
+  });
+  block.querySelectorAll('p').forEach((p) => {
+    p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
+  });
+  block.querySelectorAll('p').forEach((paragraph) => {
+    paragraph.classList.add('spectrum-Body');
+    paragraph.classList.add('spectrum-Body--sizeL');
+  });
+
+  
+
+
+}
+

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -20,8 +20,8 @@ export default async function decorate(block) {
   const arrow_button_forward = createTag('button', {class: 'slide-arrow'});
   arrow_button_forward.setAttribute('id', 'slide-arrow-forward');
   arrow_button_forward.innerHTML = '&#8250;'
-  carousel_block.append(arrow_button_previous);
-  carousel_block.append(arrow_button_forward);
+  carousel_section.append(arrow_button_previous);
+  carousel_section.append(arrow_button_forward);
 
   //add ul tag to contain carousel slides
   const carousel_ul = createTag('ul', {class: 'slides-container'});

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -7,15 +7,13 @@ export default async function decorate(block) {
   removeEmptyPTags(block);
   decorateButtons(block);
 
-  //create a div in block for ease of use
-  const carousel_block = document.getElementsByClassName('carousel block')[0];
   const carousel_block_child = createTag('div', {class: 'block-container'});
-  carousel_block.append(carousel_block_child);
+  block.append(carousel_block_child);
 
   //create div with circle progess
-  const carousel_block_circle = createTag('div', {id: 'carousel-circles'});
-  carousel_block_circle.setAttribute('class', 'carousel-circle-div');
-  carousel_block.append(carousel_block_circle);
+  const carousel_block_circle = createTag('div', {class: 'carousel-circle-div'});
+//   carousel_block_circle.classList.add('carousel-circle-div');
+  block.append(carousel_block_circle);
 
   //create section tag for animation
   const carousel_section = createTag('section', {class: 'slider-wrapper'});
@@ -23,15 +21,14 @@ export default async function decorate(block) {
 
   //add slide arrow buttons
   const arrow_button_previous = createTag('button', {class: 'slide-arrow'});
-  arrow_button_previous.setAttribute('id', 'slide-arrow-previous');
+  arrow_button_previous.classList.add('slide-arrow-previous');
   arrow_button_previous.innerHTML = '&#8249;'
   const arrow_button_forward = createTag('button', {class: 'slide-arrow'});
-  arrow_button_forward.setAttribute('id', 'slide-arrow-forward');
+  arrow_button_forward.classList.add('slide-arrow-forward');
   arrow_button_forward.innerHTML = '&#8250;'
 
   //add ul tag to contain carousel slides
   const carousel_ul = createTag('ul', {class: 'slides-container'});
-  carousel_ul.setAttribute('id', 'slides-container');
   carousel_section.append(carousel_ul);
 
   //add a count to keep track of which slide is showing
@@ -49,7 +46,7 @@ export default async function decorate(block) {
     h.parentElement.setAttribute('id', h.id);
 
     //add circle for every slide
-    let div_slide_circle = document.getElementById('carousel-circles');
+    let div_slide_circle = block.querySelector(".carousel-circle-div");
     let circle_button = createTag('button', {class: 'carousel-circle'});
     circle_button.setAttribute('id', count);
     div_slide_circle.append(circle_button);
@@ -57,7 +54,6 @@ export default async function decorate(block) {
 
     //create li tag to hold carousel slide (div)
     let carousel_li = createTag('li', {class: 'slide'});
-    // carousel_li.setAttribute('id', "li-"+h.id);
     carousel_ul.append(carousel_li);
     carousel_li.append(h.parentElement);
 
@@ -77,7 +73,7 @@ export default async function decorate(block) {
 
   //add id to image and add image to left div
   block.querySelectorAll('img').forEach((img) => {
-    img.parentElement.parentElement.setAttribute('id', 'IMAGE');
+    img.parentElement.parentElement.classList.add('IMAGE');
 
     //add image to left div
     let flex_div = createTag('div', { id: 'left-flex-div-'+img.parentElement.parentElement.parentElement.id});
@@ -88,16 +84,16 @@ export default async function decorate(block) {
 
   block.querySelectorAll('p').forEach(function (p){
     //add everything but image to the right div
-    if(p.id === "IMAGE"){
+    if(p.classList.contains("IMAGE") ){
         p.classList.add('spectrum-Body', 'spectrum-Body--sizeS', 'image-container');
     }else{
-        let button_div = document.getElementById('button-div-' + p.parentElement.id); 
+        let button_div = block.querySelector("[id=button-div-" + CSS.escape(p.parentElement.id)+ "]");
         if(p.classList.contains('button-container')){
             //add buttons to div
             button_div.classList.add('carousel-button-container');
             button_div.append(p);
         }else{
-            let flex_div = document.getElementById('right-flex-div-' + p.parentElement.id); 
+            let flex_div = block.querySelector("[id=right-flex-div-" + CSS.escape(p.parentElement.id)+ "]");
             flex_div.setAttribute('class', 'right-container');
             p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
             flex_div.insertBefore(p, button_div);
@@ -106,24 +102,24 @@ export default async function decorate(block) {
   });
 
   //slide functionality with arrow buttons
-  const slidesContainer = document.getElementById("slides-container");
+  const slidesContainer = block.querySelector(".slides-container");
   const slide = document.querySelector(".slide");
-  const prevButton = document.getElementById("slide-arrow-previous");
-  const nextButton = document.getElementById("slide-arrow-forward");
+  const prevButton = block.querySelector(".slide-arrow-previous");
+  const nextButton = block.querySelector(".slide-arrow-forward");
 
   let isPaused = false;
   
   nextButton.addEventListener("click", () => {
     isPaused = true;
     //get new slide number
-    let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
+    let slide_selected = block.querySelector(".carousel-circle-selected");
     let slide_selected_num = parseInt(slide_selected.id);
     let new_slide_num = slide_selected_num+1;
     let new_slide;
     if(new_slide_num === count){ //at last slide - can't go forward more
         
     }else{
-        new_slide = document.getElementById(new_slide_num);
+        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
         //change color of circle
         slide_selected.classList.remove('carousel-circle-selected')
         new_slide.classList.add('carousel-circle-selected');
@@ -136,14 +132,14 @@ export default async function decorate(block) {
   prevButton.addEventListener("click", () => {
     isPaused = true;
     //get new slide number
-    let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
+    let slide_selected = block.querySelector(".carousel-circle-selected"); //should only be one in the block
     let slide_selected_num = parseInt(slide_selected.id);
     let new_slide_num = slide_selected_num-1;
     let new_slide;
     if(new_slide_num === 0){ //at first slide - can't go back more
 
     }else{
-        new_slide = document.getElementById(new_slide_num);
+        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
         //change color of circle
         slide_selected.classList.remove('carousel-circle-selected');
         new_slide.classList.add('carousel-circle-selected');
@@ -160,7 +156,7 @@ export default async function decorate(block) {
   buttons.forEach((button, i) => {
     button.addEventListener("click", () => {
         isPaused = true;
-        let old_slide_num = document.getElementsByClassName('carousel-circle-selected')[0].id;
+        let old_slide_num = block.querySelector(".carousel-circle-selected").id; //should only be one in the block
         let new_slide_num = button.id;
         let difference = new_slide_num - old_slide_num;
         if(difference > 0){ //going forward
@@ -181,12 +177,12 @@ export default async function decorate(block) {
   //automatic scrolling
   function advanceSlide() {
     //get new slide number
-    let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
+    let slide_selected = block.querySelector('.carousel-circle-selected'); //should only be one in the block
     let slide_selected_num = parseInt(slide_selected.id);
     let new_slide_num = slide_selected_num+1;
     let new_slide;
     if(new_slide_num === count){ //at last slide - can't go forward more
-        new_slide = document.getElementById(1);
+        new_slide = block.querySelector("[id=" + CSS.escape(1)+ "]");
         //change color of circle
         slide_selected.classList.remove('carousel-circle-selected')
         new_slide.classList.add('carousel-circle-selected');
@@ -198,7 +194,7 @@ export default async function decorate(block) {
         //slide over to new slide
         const slideWidth = slide.clientWidth;
         slidesContainer.scrollLeft += slideWidth;
-        new_slide = document.getElementById(new_slide_num);
+        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
         //change color of circle
         new_slide.classList.add('carousel-circle-selected');
         slide_selected.classList.remove('carousel-circle-selected')
@@ -208,11 +204,11 @@ export default async function decorate(block) {
   
   function slideTimer() {
     if(!isPaused){
-        console.log("not paused");
+        // console.log("not paused");
         advanceSlide();
         setTimeout(slideTimer, 3000);
     }else{
-        console.log("paused");
+        // console.log("paused");
         clearTimeout(timer);
         //after set amount of time automatic scrolling can commence
         setTimeout(() => {isPaused = false;}, 4000);

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -1,4 +1,4 @@
-import { decorateButtons,rearrangeHeroPicture } from '../../scripts/lib-adobeio.js';
+import { createTag, decorateButtons } from '../../scripts/lib-adobeio.js';
 
 
 /**
@@ -7,19 +7,43 @@ import { decorateButtons,rearrangeHeroPicture } from '../../scripts/lib-adobeio.
  */
 export default async function decorate(block) {
   decorateButtons(block);
+
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
-    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL');
-  });
-  block.querySelectorAll('p').forEach((p) => {
-    p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-  });
-  block.querySelectorAll('p').forEach((paragraph) => {
-    paragraph.classList.add('spectrum-Body');
-    paragraph.classList.add('spectrum-Body--sizeL');
+    //add everything but image to a div
+    const flex_div = createTag('div', { id: 'flex_div' });
+    h.parentElement.append(flex_div);
+    flex_div.append(h);
+
   });
 
+  const flex_div = document.getElementById('flex_div');
+
+  block.querySelectorAll('p').forEach(function (p){
+    p.childNodes.forEach(function (child) {
+        // console.log(child.nodeName);
+        if(child.nodeName === 'PICTURE'){
+            
+            p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
+        } else {
+            console.log(child.nodeName);
+            flex_div.appendChild(p);
+        };
+    });
+    
+  });
+
+  block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
+    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL');
+    //make a flex box - row
+    h.parentElement.parentElement.classList.add('carousel-format');
+  });
+
+  block.querySelectorAll('img').forEach((img) => {
+    img.classList.add('img-size');
+  });
   
 
 
+  
 }
 

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -111,25 +111,43 @@ export default async function decorate(block) {
   nextButton.addEventListener("click", () => {
     //change circle color 
     let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
-    let slide_selected_id = slide_selected.id;
-    let new_slide = document.getElementById(parseInt(slide_selected_id)+1);
-    slide_selected.classList.remove('carousel-circle-selected')
-    new_slide.classList.add('carousel-circle-selected');
-    //slide over to new slide
-    const slideWidth = slide.clientWidth;
-    slidesContainer.scrollLeft += slideWidth;
+    let slide_selected_num = parseInt(slide_selected.id);
+    let new_slide_num = slide_selected_num+1;
+    let new_slide;
+    console.log(new_slide_num);
+    if(new_slide_num === count){ //at last slide - can't go forward more
+        
+    }else{
+        new_slide = document.getElementById(new_slide_num);
+        slide_selected.classList.remove('carousel-circle-selected')
+        new_slide.classList.add('carousel-circle-selected');
+        //slide over to new slide
+        const slideWidth = slide.clientWidth;
+        slidesContainer.scrollLeft += slideWidth;
+    };  
   });
 
   prevButton.addEventListener("click", () => {
     //change circle color 
     let slide_selected = document.getElementsByClassName('carousel-circle-selected')[0]
-    let slide_selected_id = slide_selected.id;
-    let new_slide = document.getElementById(parseInt(slide_selected_id)-1);
-    slide_selected.classList.remove('carousel-circle-selected')
-    new_slide.classList.add('carousel-circle-selected');
-    //slide over to new slide
-    const slideWidth = slide.clientWidth;
-    slidesContainer.scrollLeft -= slideWidth;
+    let slide_selected_num = parseInt(slide_selected.id);
+    let new_slide_num = slide_selected_num-1;
+    let new_slide;
+    console.log("previous");
+    console.log(slide_selected_num);
+
+    console.log(new_slide_num);
+
+    if(new_slide_num === 0){ //at first slide - can't go back more
+
+    }else{
+        slide_selected.classList.remove('carousel-circle-selected');
+        new_slide = document.getElementById(new_slide_num);
+        new_slide.classList.add('carousel-circle-selected');
+        //slide over to new slide
+        const slideWidth = slide.clientWidth;
+        slidesContainer.scrollLeft -= slideWidth;
+    };
   });
 
   //change color of circle button when clicked

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -6,11 +6,12 @@ import { createTag, decorateButtons, removeEmptyPTags} from '../../scripts/lib-a
  */
 export default async function decorate(block) {
   removeEmptyPTags(block);
+  decorateButtons(block);
 
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     //create flex display
     h.parentElement.classList.add('carousel-container');
-    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL');
+    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL', 'carousel-heading');
 
     h.parentElement.setAttribute('id', h.id);
 
@@ -51,13 +52,7 @@ export default async function decorate(block) {
             p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
             flex_div.insertBefore(p, button_div);
         }
-        
-
-        
     };
   });
-
-  decorateButtons(block);
-
 }
 

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -62,6 +62,7 @@ export default async function decorate(block) {
     h.parentElement.append(flex_div);
     flex_div.append(h);
 
+    //add buttons to a button div so they can be next to each other
     let button_div = createTag('div', { id: 'button-div-'+h.id});
     h.parentElement.append(button_div);
 
@@ -73,8 +74,8 @@ export default async function decorate(block) {
 
   //add id to image and add image to left div
   block.querySelectorAll('img').forEach((img) => {
+    //to identify image later
     img.parentElement.parentElement.classList.add('IMAGE');
-
     //add image to left div
     let flex_div = createTag('div', { id: 'left-flex-div-'+img.parentElement.parentElement.parentElement.id});
     img.parentElement.parentElement.parentElement.append(flex_div);
@@ -85,7 +86,7 @@ export default async function decorate(block) {
   block.querySelectorAll('p').forEach(function (p){
     //add everything but image to the right div
     if(p.classList.contains("IMAGE") ){
-        p.classList.add('spectrum-Body', 'spectrum-Body--sizeS', 'image-container');
+        p.classList.add('image-container');
     }else{
         let button_div = block.querySelector("[id=button-div-" + CSS.escape(p.parentElement.id)+ "]");
         if(p.classList.contains('button-container')){
@@ -107,6 +108,7 @@ export default async function decorate(block) {
   const prevButton = block.querySelector(".slide-arrow-previous");
   const nextButton = block.querySelector(".slide-arrow-forward");
 
+  //for automatic scrolling
   let isPaused = false;
   
   nextButton.addEventListener("click", () => {
@@ -122,8 +124,8 @@ export default async function decorate(block) {
         //slide over to new slide
         const slideDx = slidesContainer.clientLeft + (slide.clientWidth * slide_selected_num);
         slidesContainer.scrollLeft = slideDx;
-        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
         //change color of circle
+        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
         slide_selected.classList.remove('carousel-circle-selected')
         new_slide.classList.add('carousel-circle-selected');
     };  
@@ -140,18 +142,12 @@ export default async function decorate(block) {
 
     }else{
       //slide over to new slide
-      console.log("width: " + slide.clientWidth);
-      console.log("slidesContainer: " + slidesContainer.scrollLeft);
       const slideDx = (new_slide_num-1) * slide.clientWidth;
-      // console.log("first: " +  (slide.clientWidth * (count - 2)));
-      console.log("slideDx: " + slideDx);
       slidesContainer.scrollLeft = slideDx;
-
-      new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
       //change color of circle
+      new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
       slide_selected.classList.remove('carousel-circle-selected');
       new_slide.classList.add('carousel-circle-selected');
-
     };
   });
 
@@ -161,23 +157,10 @@ export default async function decorate(block) {
   
   buttons.forEach((button, i) => {
     button.addEventListener("click", () => {
-        isPaused = true;
-        // let old_slide_num = block.querySelector(".carousel-circle-selected").id; //should only be one in the block
-        
+        isPaused = true;        
         let new_slide_num = button.id;
         const slideDx = slidesContainer.clientLeft + (slide.clientWidth * (new_slide_num-1));
         slidesContainer.scrollLeft = slideDx;
-
-        // let difference = new_slide_num - old_slide_num;
-        // if(difference > 0){ //going forward    
-        
-            // const slideWidth = slide.clientWidth;
-            // slidesContainer.scrollLeft += (difference * slideWidth);
-        // }else{ //going back
-        //     const slideWidth = slide.clientWidth;
-        //     slidesContainer.scrollLeft -= (-difference * slideWidth);
-        // };
-
         //change circle color
         buttons.forEach((button) =>
             button.classList.remove('carousel-circle-selected')
@@ -204,31 +187,28 @@ export default async function decorate(block) {
         slidesContainer.scrollLeft -= (difference*slideWidth);
     }else{
         //slide over to new slide
-        const slideWidth = slide.clientWidth;
-        slidesContainer.scrollLeft += slideWidth;
-        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
+        const slideDx = slidesContainer.clientLeft + (slide.clientWidth * slide_selected_num);
+        slidesContainer.scrollLeft = slideDx;
         //change color of circle
+        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
         new_slide.classList.add('carousel-circle-selected');
         slide_selected.classList.remove('carousel-circle-selected')
-        
     };  
   };
   
   function slideTimer() {
     if(!isPaused){
-        // console.log("not paused");
         advanceSlide();
-        setTimeout(slideTimer, 3000);
+        setTimeout(slideTimer, 9000);
     }else{
-        // console.log("paused");
         clearTimeout(timer);
         //after set amount of time automatic scrolling can commence
-        setTimeout(() => {isPaused = false;}, 4000);
-        setTimeout(slideTimer, 3000);
+        setTimeout(() => {isPaused = false;}, 18000);
+        setTimeout(slideTimer, 9000);
     };   
   };
 
-  const timer = setTimeout(slideTimer, 3000);
+  const timer = setTimeout(slideTimer, 9000);
   timer;
 
 }

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -118,14 +118,14 @@ export default async function decorate(block) {
     let new_slide;
     if(new_slide_num === count){ //at last slide - can't go forward more
         
-    }else{
+    } else {
+        //slide over to new slide
+        const slideDx = slidesContainer.scrollLeft + (slide.clientWidth * slide_selected_num);
+        slidesContainer.scrollLeft = slideDx;
         new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
         //change color of circle
         slide_selected.classList.remove('carousel-circle-selected')
         new_slide.classList.add('carousel-circle-selected');
-        //slide over to new slide
-        const slideWidth = slide.clientWidth;
-        slidesContainer.scrollLeft += slideWidth;
     };  
   });
 
@@ -139,13 +139,15 @@ export default async function decorate(block) {
     if(new_slide_num === 0){ //at first slide - can't go back more
 
     }else{
-        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
-        //change color of circle
-        slide_selected.classList.remove('carousel-circle-selected');
-        new_slide.classList.add('carousel-circle-selected');
-        //slide over to new slide
-        const slideWidth = slide.clientWidth;
-        slidesContainer.scrollLeft -= slideWidth;
+      //slide over to new slide
+      const slideDx = slidesContainer.scrollLeft - (slide.clientWidth * slide_selected_num);
+      slidesContainer.scrollLeft = slideDx;
+
+      new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
+      //change color of circle
+      slide_selected.classList.remove('carousel-circle-selected');
+      new_slide.classList.add('carousel-circle-selected');
+
     };
   });
 

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -120,7 +120,7 @@ export default async function decorate(block) {
         
     } else {
         //slide over to new slide
-        const slideDx = slidesContainer.scrollLeft + (slide.clientWidth * slide_selected_num);
+        const slideDx = slidesContainer.clientLeft + (slide.clientWidth * slide_selected_num);
         slidesContainer.scrollLeft = slideDx;
         new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
         //change color of circle
@@ -140,7 +140,11 @@ export default async function decorate(block) {
 
     }else{
       //slide over to new slide
-      const slideDx = slidesContainer.scrollLeft - (slide.clientWidth * slide_selected_num);
+      console.log("width: " + slide.clientWidth);
+      console.log("slidesContainer: " + slidesContainer.scrollLeft);
+      const slideDx = (new_slide_num-1) * slide.clientWidth;
+      // console.log("first: " +  (slide.clientWidth * (count - 2)));
+      console.log("slideDx: " + slideDx);
       slidesContainer.scrollLeft = slideDx;
 
       new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
@@ -158,16 +162,22 @@ export default async function decorate(block) {
   buttons.forEach((button, i) => {
     button.addEventListener("click", () => {
         isPaused = true;
-        let old_slide_num = block.querySelector(".carousel-circle-selected").id; //should only be one in the block
+        // let old_slide_num = block.querySelector(".carousel-circle-selected").id; //should only be one in the block
+        
         let new_slide_num = button.id;
-        let difference = new_slide_num - old_slide_num;
-        if(difference > 0){ //going forward
-            const slideWidth = slide.clientWidth;
-            slidesContainer.scrollLeft += (difference * slideWidth);
-        }else{ //going back
-            const slideWidth = slide.clientWidth;
-            slidesContainer.scrollLeft -= (-difference * slideWidth);
-        };
+        const slideDx = slidesContainer.clientLeft + (slide.clientWidth * (new_slide_num-1));
+        slidesContainer.scrollLeft = slideDx;
+
+        // let difference = new_slide_num - old_slide_num;
+        // if(difference > 0){ //going forward    
+        
+            // const slideWidth = slide.clientWidth;
+            // slidesContainer.scrollLeft += (difference * slideWidth);
+        // }else{ //going back
+        //     const slideWidth = slide.clientWidth;
+        //     slidesContainer.scrollLeft -= (-difference * slideWidth);
+        // };
+
         //change circle color
         buttons.forEach((button) =>
             button.classList.remove('carousel-circle-selected')
@@ -208,18 +218,18 @@ export default async function decorate(block) {
     if(!isPaused){
         // console.log("not paused");
         advanceSlide();
-        setTimeout(slideTimer, 9000);
+        setTimeout(slideTimer, 3000);
     }else{
         // console.log("paused");
         clearTimeout(timer);
         //after set amount of time automatic scrolling can commence
-        setTimeout(() => {isPaused = false;}, 18000);
-        setTimeout(slideTimer, 9000);
+        setTimeout(() => {isPaused = false;}, 4000);
+        setTimeout(slideTimer, 3000);
     };   
   };
 
-//   const timer = setTimeout(slideTimer, 9000);
-//   timer;
+  const timer = setTimeout(slideTimer, 3000);
+  timer;
 
 }
 


### PR DESCRIPTION
## Description

Created a carousel content block that takes in an image, heading, body, and link(s) and displays it in a slide. There can be multiple slides in a carousel (up to 5) and they are automatically scrolled through at 9 second intervals - when the manual next/previous buttons are pressed the automatic scrolling pauses for 18 seconds in order to let the user look at the slide. 

## Related Issue

DEVSITE-794. Ticket part of the intern project - migrating multiple content blocks from Gatsby to Franklin 

## Motivation and Context

The carousel content block is needed by teams in Adobe that are using Franklin to populate their sites. This content block is available in Gatsby but is also needed in Franklin.

## How Has This Been Tested?

This code adds a new functionality to Adobe Franklin sites but does not change the functionality of other parts. The carousel was tested by me and Tim and whenever a bug or error was found we fixed it. 

## Screenshots (if appropriate):
<img width="882" alt="Screenshot 2023-07-26 at 9 28 22 AM" src="https://github.com/adobe/adobe-io-website/assets/41382203/4b873111-72c5-4968-8a2d-000eb04c41ac">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
