### PR TITLE
feat: added carousel

### DIFF
--- a/hlx_statics/blocks/carousel/carousel.css
+++ b/hlx_statics/blocks/carousel/carousel.css
@@ -1,0 +1,137 @@
+picture {
+    width: 100%;
+    height: 100%;
+    display: flex;
+}
+
+picture img {
+    object-fit: cover;
+    height: auto;
+    width: 100%;
+}
+
+main div.carousel .image-container {
+    height: 300px;
+    max-width: 602px;
+}
+
+main div.carousel {
+    width: var(--spectrum-global-dimension-static-grid-fixed-max-width);
+    margin: auto;
+}
+
+main div.carousel .block-container {
+    display: flex;
+    flex-direction: row ;
+    justify-content: center;
+    align-content: space-between;
+    position: relative;
+}
+
+main div.carousel .carousel-heading {
+    margin-top: 1 !important;
+    margin-bottom: var(--spectrum-global-dimension-size-100) !important;
+  }
+
+main div.carousel .carousel-container {
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+    align-content: space-between;
+}
+
+main div.carousel .left-container {
+    flex: 0 1 50%;
+    min-height: 100%;
+    max-width: 50%;
+    padding: 0 var(--spectrum-global-dimension-size-100);
+}
+
+main div.carousel .right-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 0 1 50%;
+    min-height: 100%;
+    max-width: 50%;
+    padding: 0 var(--spectrum-global-dimension-size-400);
+}
+
+main div.carousel .carousel-button-container {
+    display: flex;
+    flex-direction: row !important;
+    margin-top: var(--spectrum-global-dimension-size-100);
+    gap: var(--spectrum-global-dimension-size-200);
+}
+
+main div.carousel .slider-wrapper {
+    position: relative;
+    overflow: hidden;
+    transition-property: transform;
+    box-sizing: content-box;
+    align-items: center;
+}
+
+main div.carousel .slides-container {
+    width: 100%;
+    display: flex;
+    list-style: none;
+    margin: 1;
+    padding: 0;
+    margin-bottom: 1;
+    margin-top: 1;
+    overflow: hidden;
+    scroll-behavior: smooth;
+}
+
+main div.carousel .slide {
+    width: 100%;
+    height: 100%;
+    flex: 1 0 100%;
+}
+
+main div.carousel .slide-arrow {
+    margin: auto;
+    background-color: transparent; 
+    border: none;
+    font-size: 5rem;
+    color: #b3cef7;
+    cursor: pointer;
+}
+
+main .carousel .slide-arrow:hover,
+main .carousel .slide-arrow:focus {
+    color: #007aff;
+}
+
+main div.carousel .slides-container {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none;  /* Internet Explorer 10+ */
+}
+
+/* WebKit */
+main div.carousel .slides-container::-webkit-scrollbar { 
+    width: 0;
+    height: 0;
+}
+
+main div.carousel .carousel-circle-div {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
+
+main div.carousel .carousel-circle {
+    background-color: #c6c6c6;
+    border: none;
+    border-radius: 100%;
+    width: 12px;
+    height: 12px;
+    margin: 4px 2px;
+    cursor: pointer;
+}
+
+main div.carousel .carousel-circle-selected {
+    background-color: #007aff !important;
+}

--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -1,0 +1,192 @@
+import { createTag, decorateButtons, removeEmptyPTags} from '../../scripts/lib-adobeio.js';
+/**
+ * decorates the carousel
+ * @param {Element} block The carousel block element
+ */
+export default async function decorate(block) {
+  removeEmptyPTags(block);
+  decorateButtons(block);
+
+  const carousel_block_child = createTag('div', {class: 'block-container'});
+  block.append(carousel_block_child);
+
+  const carousel_block_circle = createTag('div', {class: 'carousel-circle-div'});
+  block.append(carousel_block_circle);
+
+  const carousel_section = createTag('section', {class: 'slider-wrapper'});
+  carousel_block_child.append(carousel_section);
+
+  const arrow_button_previous = createTag('button', {class: 'slide-arrow'});
+  arrow_button_previous.classList.add('slide-arrow-previous');
+  arrow_button_previous.innerHTML = '&#8249;'
+  const arrow_button_forward = createTag('button', {class: 'slide-arrow'});
+  arrow_button_forward.classList.add('slide-arrow-forward');
+  arrow_button_forward.innerHTML = '&#8250;'
+
+  const carousel_ul = createTag('ul', {class: 'slides-container'});
+  carousel_section.append(carousel_ul);
+  
+  //add a count to keep track of which slide is showing
+  let count = 1;
+
+  block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
+    h.parentElement.classList.add('carousel-container');
+    h.parentElement.parentElement.replaceWith(carousel_block_child);
+    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL', 'carousel-heading');
+    h.parentElement.setAttribute('id', h.id);
+
+    //add circle for every slide
+    let div_slide_circle = block.querySelector(".carousel-circle-div");
+    let circle_button = createTag('button', {class: 'carousel-circle'});
+    circle_button.setAttribute('id', count);
+    div_slide_circle.append(circle_button);
+    count += 1;
+
+    let carousel_li = createTag('li', {class: 'slide'});
+    carousel_ul.append(carousel_li);
+    carousel_li.append(h.parentElement);
+
+    //add everything but image to the left div
+    let flex_div = createTag('div', { id: 'right-flex-div-'+h.id});
+    h.parentElement.append(flex_div);
+    flex_div.append(h);
+
+    let button_div = createTag('div', { id: 'button-div-'+h.id});
+    h.parentElement.append(button_div);
+
+  });
+
+  carousel_block_child.insertBefore(arrow_button_previous, carousel_section);
+  carousel_block_child.append(arrow_button_forward);
+
+  //add id to image and add image to left div
+  block.querySelectorAll('img').forEach((img) => {
+    img.parentElement.parentElement.classList.add('IMAGE');
+    //add image to left div
+    let flex_div = createTag('div', { id: 'left-flex-div-'+img.parentElement.parentElement.parentElement.id});
+    img.parentElement.parentElement.parentElement.append(flex_div);
+    flex_div.append(img.parentElement.parentElement);
+    flex_div.classList.add('left-container');
+  });
+
+  block.querySelectorAll('p').forEach(function (p){
+    //add everything but image to the right div
+    if(p.classList.contains("IMAGE") ){
+        p.classList.add('image-container');
+    }else{
+        let button_div = block.querySelector("[id=button-div-" + p.parentElement.id + "]");
+        if(p.classList.contains('button-container')){
+            button_div.classList.add('carousel-button-container');
+            button_div.append(p);
+        }else{
+            let flex_div = block.querySelector("[id=right-flex-div-" + p.parentElement.id + "]");
+            flex_div.setAttribute('class', 'right-container');
+            p.classList.add('spectrum-Body', 'spectrum-Body--sizeM');
+            flex_div.insertBefore(p, button_div);
+        }
+    };
+  });
+
+  //slide functionality with arrow buttons
+  const slidesContainer = block.querySelector(".slides-container");
+  const slide = block.querySelector(".slide");
+  const prevButton = block.querySelector(".slide-arrow-previous");
+  const nextButton = block.querySelector(".slide-arrow-forward");
+
+  //for automatic scrolling
+  let isPaused = false;
+  
+  nextButton.addEventListener("click", () => {
+    isPaused = true;
+    let slide_selected = block.querySelector(".carousel-circle-selected");
+    let slide_selected_num = parseInt(slide_selected.id);
+    let new_slide_num = slide_selected_num+1;
+    let new_slide;
+    if(new_slide_num !== count){ //at last slide - can't go forward more
+      //slide over to new slide
+      const slideDx = slidesContainer.clientLeft + (slide.clientWidth * slide_selected_num);
+      slidesContainer.scrollLeft = slideDx;
+      //change color of circle
+      new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
+      slide_selected.classList.remove('carousel-circle-selected')
+      new_slide.classList.add('carousel-circle-selected'); 
+    };  
+  });
+
+  prevButton.addEventListener("click", () => {
+    isPaused = true;
+    let slide_selected = block.querySelector(".carousel-circle-selected"); //should only be one in the block
+    let slide_selected_num = parseInt(slide_selected.id);
+    let new_slide_num = slide_selected_num-1;
+    let new_slide;
+    if(new_slide_num !== 0){ //at first slide - can't go back more
+        //slide over to new slide
+        const slideDx = (new_slide_num-1) * slide.clientWidth;
+        slidesContainer.scrollLeft = slideDx;
+        //change color of circle
+        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
+        slide_selected.classList.remove('carousel-circle-selected');
+        new_slide.classList.add('carousel-circle-selected');
+    };
+  });
+
+  //change color of circle button when clicked
+  const buttons = block.querySelectorAll('.carousel-circle');
+  buttons[0].classList.add('carousel-circle-selected'); //when reloading first slide should be selected
+  
+  buttons.forEach((button, i) => {
+    button.addEventListener("click", () => {
+        isPaused = true;        
+        let new_slide_num = button.id;
+        const slideDx = slidesContainer.clientLeft + (slide.clientWidth * (new_slide_num-1));
+        slidesContainer.scrollLeft = slideDx;
+        //change circle color
+        buttons.forEach((button) =>
+            button.classList.remove('carousel-circle-selected')
+        );
+        button.classList.add('carousel-circle-selected');
+    });
+  });
+
+  //automatic scrolling
+  function advanceSlide() {
+    let slide_selected = block.querySelector('.carousel-circle-selected'); 
+    let slide_selected_num = parseInt(slide_selected.id);
+    let new_slide_num = slide_selected_num+1;
+    let new_slide;
+    if(new_slide_num === count){ //at last slide - can't go forward more
+        new_slide = block.querySelector("[id=" + CSS.escape(1)+ "]");
+        //change color of circle
+        slide_selected.classList.remove('carousel-circle-selected')
+        new_slide.classList.add('carousel-circle-selected');
+        //slide over to new slide - needs to start over
+        const difference = count - 1 - 1;
+        const slideWidth = slide.clientWidth;
+        slidesContainer.scrollLeft -= (difference*slideWidth);
+    }else{
+        //slide over to new slide
+        const slideDx = slidesContainer.clientLeft + (slide.clientWidth * slide_selected_num);
+        slidesContainer.scrollLeft = slideDx;
+        //change color of circle
+        new_slide = block.querySelector("[id=" + CSS.escape(new_slide_num)+ "]");
+        new_slide.classList.add('carousel-circle-selected');
+        slide_selected.classList.remove('carousel-circle-selected')
+    };  
+  };
+  
+  function slideTimer() {
+    if(!isPaused){
+        advanceSlide();
+        setTimeout(slideTimer, 9000);
+    }else{
+        clearTimeout(timer);
+        //after set amount of time automatic scrolling can commence
+        setTimeout(() => {isPaused = false;}, 18000);
+        setTimeout(slideTimer, 9000);
+    };   
+  };
+
+  const timer = setTimeout(slideTimer, 9000);
+  timer;
+
+}


### PR DESCRIPTION
## Description

Created a carousel content block that takes in an image, heading, body, and link(s) and displays it in a slide. There can be multiple slides in a carousel (up to 5) and they are automatically scrolled through at 9 second intervals - when the manual next/previous buttons are pressed the automatic scrolling pauses for 18 seconds in order to let the user look at the slide. 

## Related Issue

DEVSITE-794. Ticket part of the intern project - migrating multiple content blocks from Gatsby to Franklin 

## Motivation and Context

The carousel content block is needed by teams in Adobe that are using Franklin to populate their sites. This content block is available in Gatsby but is also needed in Franklin.

## How Has This Been Tested?

This code adds a new functionality to Adobe Franklin sites but does not change the functionality of other parts. The carousel was tested by me and Tim and whenever a bug or error was found we fixed it. 

## Screenshots (if appropriate):
<img width="882" alt="Screenshot 2023-07-26 at 9 28 22 AM" src="https://github.com/adobe/adobe-io-website/assets/41382203/4b873111-72c5-4968-8a2d-000eb04c41ac">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
