### PR TITLE
Site hero block correctly mirrors Gatsby style

### DIFF
--- a/hlx_statics/blocks/site-hero/site-hero.css
+++ b/hlx_statics/blocks/site-hero/site-hero.css
@@ -1,81 +1,109 @@
 main div.site-hero-container {
-    background: var(--spectrum-global-color-gray-50);
-    background-position: center;
-    background-size: cover;
-    padding: 0 !important;
+  background: var(--spectrum-global-color-gray-50);
+  background-position: center;
+  background-size: cover;
+  padding: 0 !important;
+}
+  
+main div.site-hero {
+  position: relative;
+  width: 100%;
+  height: 350px;
+}
+
+main .xl div.site-hero {
+  position: relative;
+  width: 100%;
+  height: 624px !important;
+}
+
+main div.site-hero .site-hero-content {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0 25%;
+  height: 100%;
+  max-width: 100% !important; 
+}
+
+
+main .site-hero img {
+  width: 100%;
+  height: 350px;
+  object-fit: cover;
+}
+
+main .xl .xl-img{
+  width: 100%;
+  height: 624px !important;
+  object-fit: cover;
+}
+
+
+main .site-hero h1 {
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: var(--spectrum-global-dimension-size-200);
+}
+
+main .site-hero p.spectrum-Body--sizeL {
+  margin-top: 0 !important;
+  font-size: var(--spectrum-global-dimension-size-225);
+  color: var(--spectrum-global-color-gray-800) !important;
+}
+  
+main .site-hero .hero-button-container {
+  display: flex;
+  flex-wrap: wrap;
+  display: inline-flex;
+  margin-top: var(--spectrum-global-dimension-size-225);
+  gap: var(--spectrum-global-dimension-size-200, var(--spectrum-alias-size-200));
+}
+
+
+@media screen and (max-width: 1024px) {
+  main div.site-hero .site-hero-content{
+    padding: 0 var(--spectrum-global-dimension-size-400);
   }
   
+  main .site-hero img {
+    width: 100%;
+    height: 350px;
+    object-fit: cover;
+  }
+  
+  main .xl .xl-img{
+    width: 100%;
+    height: 624px !important;
+    object-fit: cover;
+  }
+}
+
+
+@media screen and (max-width: 768px) {
   main div.site-hero {
     position: relative;
     width: 100%;
-  }
-  @media screen and (max-width:768px) {
-    main div.site-hero {
-      height: 350px;
-    }
-    main .site-hero div{
-      width: 95%;
-    }
-  }
-  @media screen and (max-width: 1024px) {
-    main .xl div.site-hero{
-      height: 100vh;
-    }
-    main div.site-hero .xl-img {
-      height: 100vh;
-      object-fit: cover;
-    }
+    height: 100vh !important  
   }
 
-  main div.site-hero > div:first-child {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    height: 100%;
-  }
-    
-  main .site-hero h1 {
-    margin-top: 0;
-    margin-bottom: var(--spectrum-global-dimension-size-200);
-  }
-  
-  main .site-hero p.spectrum-Body--sizeL {
-    margin-top: 0 !important;
-    font-size: var(--spectrum-global-dimension-size-225);
-    color: var(--spectrum-global-color-gray-800) !important;
-  }
-  
-  /* main .site-hero h1 + p.last-of-type {
-    margin-bottom: 0 !important;
-  } */
-  
-  main .site-hero .hero-button-container {
-    display: flex;
-    flex-wrap: wrap;
-    display: inline-flex;
-  
-    margin-top: var(--spectrum-global-dimension-size-225);
-    gap: var(--spectrum-global-dimension-size-200, var(--spectrum-alias-size-200));
+  main .xl div.site-hero {
+    position: relative;
+    width: 100%;
+    height: 100vh !important;
   }
 
-  @media screen and (min-width:1025px) {
-    main div.site-hero .xl-img {
-      width: 100%;
-      max-height: 624px !important;
-      object-fit: cover;
-    }
-  }
-  @media screen and (min-width:769px) {
-    main .site-hero img {
-      width: 100%;
-      max-height: 350px;
-      object-fit: cover;
-    }
-    main .xl .xl-img{
-      max-height: none;
-    }
+  main div.site-hero img {
+    overflow-clip-margin: content-box;
+    overflow: clip;
+    height: 100vh !important;
   }
 
-
+  main div.site-hero .xl-img {
+    overflow-clip-margin: content-box;
+    overflow: clip;
+    height: 100vh !important;
+  } 
+}

--- a/hlx_statics/blocks/site-hero/site-hero.js
+++ b/hlx_statics/blocks/site-hero/site-hero.js
@@ -1,6 +1,5 @@
 import {
   removeEmptyPTags,
-  rearrangeHeroPicture,
   decorateButtons,
   createTag
 } from '../../scripts/lib-adobeio.js';
@@ -19,6 +18,7 @@ export default async function decorate(block) {
   block.classList.add('spectrum--dark');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL', 'spectrum-Heading--serif');
+    h.parentElement.classList.add('site-hero-content');
     h.parentElement.append(button_div);
   });
   
@@ -33,15 +33,9 @@ export default async function decorate(block) {
     }
   });
 
-  const overlayStyle = 'position: absolute; display: flex; left: 50%; top: 50%;  transform: translate(-50%, -50%); text-align: center';
-  rearrangeHeroPicture(block, overlayStyle);
-
   if(document.querySelectorAll('.xl img').length === 1){
-    const hero_picture = document.querySelectorAll('.xl picture')[0];
-    hero_picture.style.setProperty('align-items', '');
     const hero_img = document.querySelectorAll('.xl img')[0];
     hero_img.removeAttribute('style');
     hero_img.setAttribute('class', 'xl-img');
   }
-  
 }


### PR DESCRIPTION
Migrating correct functionality of site hero block to franklin 

## Description

Added mobile and tablet breakpoints and section metadata for normal and xl image sizes

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The franklin site hero component wasn't working correctly 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
