### PR TITLE
Fix the way to read the subfolders

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -337,7 +337,6 @@ export const setSearchFrameOrigin = (host, suffix = '') => {
  * @returns The first subfolder in the franklin dir - for special urls like apis will return the franklin_assets folder
  */
 export const getClosestFranklinSubfolder = (host, suffix = '') => {
-  //const subfolders = window.location.pathname.split('/');
   let subfolderPath = window.location.pathname.split('/')[1];
 
   // make sure top level paths point to the same nav if on these paths

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -337,20 +337,17 @@ export const setSearchFrameOrigin = (host, suffix = '') => {
  * @returns The first subfolder in the franklin dir - for special urls like apis will return the franklin_assets folder
  */
 export const getClosestFranklinSubfolder = (host, suffix = '') => {
+  //const subfolders = window.location.pathname.split('/');
   let subfolderPath = window.location.pathname.split('/')[1];
 
   // make sure top level paths point to the same nav if on these paths
   if (subfolderPath === '' || subfolderPath === 'apis' || subfolderPath === 'open' || subfolderPath === 'developer-support') {
     subfolderPath = 'franklin_assets';
   } else {
-    // get those peksy non-trailing / urls 
-    if(window.location.pathname.split('/').length === 2){
-      subfolderPath = window.location.pathname;
-    } else {
-      // get closest level dir and strip trailing slash
-      subfolderPath = window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/'));
-    }
-    // strip any leading slash 
+    subfolderPath = window.location.pathname;
+    // strip any ending slash
+    if (subfolderPath.charAt(subfolderPath.length-1) === '/') subfolderPath = subfolderPath.substring(0, subfolderPath.length-1);
+    // strip any leading slash
     if (subfolderPath.charAt(0) === '/') subfolderPath = subfolderPath.substring(1);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Issue was reading /express/community without a slash will return only express which is incorrect.
## Description

<!--- Describe your changes in detail -->

## Related Issue
devsite-926 - 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
