### PR TITLE
fix: heading jumping up in hero

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -221,7 +221,7 @@ export function buildHeadings(container) {
     { elementName: 'h6', blockName: 'heading6' },
   ];
   map.forEach(({ elementName, blockName }) => {
-    const elements = [...container.querySelectorAll(elementName)];
+    const elements = [...container.querySelectorAll(`main > div > ${elementName}`)];
     elements.forEach((element) => {
       const block = buildBlock(blockName, element.outerHTML);
       element.replaceWith(block);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Issue: h1 jumps to the top of hero block
Root cause: Heading blocks were created out of all h tags - regardless of whether they were  contained in another block like hero                    
Fix: Only create heading block from h tags that are default content

## Related Issue

Hackathon

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

https://heading-jumping-up-in-hero--adobe-io-website--adobe.hlx.page/

## Screenshots (if appropriate):

[Before](https://fresh-spectrum--adobe-io-website--adobe.hlx.page/): 
<img width="1728" alt="before" src="https://github.com/user-attachments/assets/fbef122d-ebde-4399-a4d2-39bfac6b44b2">
[After](https://heading-jumping-up-in-hero--adobe-io-website--adobe.hlx.page/): 
<img width="1728" alt="after" src="https://github.com/user-attachments/assets/a9beed49-ca5d-4e28-8c3c-9887156259b5">



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
