### PR TITLE
fix: added back in 1192 changes from stage

### DIFF
--- a/hlx_statics/blocks/columns/columns.css
+++ b/hlx_statics/blocks/columns/columns.css
@@ -72,6 +72,13 @@ main div.columns-container.section[data-list-class="checkmark"] ul > li:before{
     }
 }
 
+main div.columns  div.second-column div.button-group-container {
+    gap: 2rem;
+    display: flex;
+    text-align: center;
+    margin-top: 1rem;
+}
+
 @media screen and (max-width: 620px) {
     main div.columns div.first-column img {
         width: 100vw;
@@ -143,14 +150,6 @@ main div.columns h3.column-header + p {
     margin-top: 0!important;
 }
 
-main div.columns p + p {
-    margin-top: 24px;
-}
-
-main div.columns div.product-link-container p {
-    margin-top: 24px;
-}
-
 main div.columns div.listing.second-column[data-align="right"]{
     text-align: right;
     width: auto;
@@ -160,29 +159,26 @@ main div.columns div.listing ul {
     text-align: left;
 }
 
-@media screen and (min-width:768px) {
-    main div.columns div.product-link-container p + p {
-        margin-left: 24px;
-    }
-}
-
 main div.second-column div.product-link-container {
     display: flex;
     flex-direction: row;
+    gap: 1rem;
 }
 
 @media screen and (max-width:768px) {
     main div.second-column div.product-link-container {
         flex-wrap: wrap;
+        justify-content: center;
     }
     main div.columns div.product-link-container p {
-        width: 150px;
+        max-width: 150px;
     }
 }
 
 main div.second-column div.product-link-container p.icon-container {
     display: flex;
     align-items: center;
+    gap: 0.5rem;
 }
 
 main div.second-column div.product-link-container img {
@@ -195,10 +191,6 @@ main div.second-column div.product-link-container svg {
     height: 32px;
     width: 32px;
     object-fit: contain;
-}
-
-main div.second-column div.product-link-container a {
-    margin-left: 8px;
 }
 
 /* metadata: style: center */

--- a/hlx_statics/blocks/columns/columns.js
+++ b/hlx_statics/blocks/columns/columns.js
@@ -53,12 +53,20 @@ export default async function decorate(block) {
     decorateAnchorLink(h);
   });
   block.querySelectorAll('p').forEach((p) => {
-    const hasLinks = p.querySelectorAll('a, button');
-    // don't attach to icon container or if p tag contains links
-    if (!p.classList.contains('icon-container') && hasLinks.length === 0) {
+    const hasIcons = p.querySelectorAll('span.icon');
+    // don't attach to icon container or if p tag contains icons
+    if (!p.classList.contains('icon-container') && hasIcons.length === 0) {
       p.classList.add('spectrum-Body', 'spectrum-Body--sizeM');
-    } else if (hasLinks.length > 0) {
+    } else if (hasIcons.length > 0) {
       p.classList.add('icon-container');
+      // Wraps non-hyperlinked text after icon in a paragraph tag
+      p.childNodes.forEach( (child) => {
+        if (child.nodeType === Node.TEXT_NODE) {
+          const textParagraph = createTag('p', {class:'icon-text'});
+          textParagraph.innerText = child.textContent;
+          p.replaceChild(textParagraph, child);
+        }
+      });
     }
   });
 
@@ -109,11 +117,17 @@ export default async function decorate(block) {
   });
 
   block.querySelectorAll('div > div.second-column').forEach((secondColumn) => {
-    const productLinkContainer = createTag('div', { class: 'product-link-container' });
-    secondColumn.querySelectorAll('p.icon-container').forEach((innerSecond) => {
-      productLinkContainer.append(innerSecond);
-    });
-    secondColumn.append(productLinkContainer);
+    const prevElement = secondColumn.querySelector('p.icon-container')?.previousElementSibling;
+    // Only wrap in prdouct link container div if element container icon container
+    if (prevElement)
+    {
+      const productLinkContainer = createTag('div', { class: 'product-link-container' });
+      secondColumn.querySelectorAll('p.icon-container').forEach((innerSecond) => {
+        productLinkContainer.append(innerSecond);
+      });
+      // Maintains order within column card
+      prevElement.after(productLinkContainer);
+    }
   });
   const observer = new IntersectionObserver((entries) => {
     if (entries.some((e) => e.isIntersecting)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Made icons appear in columns without a link.

I made an if statement so that that even text gets added to the product link container div. I also enwrapped non-links in an paragraph tag with class "icon-text", so that there would be some space between the icon and the text next to it.

## Related Issue
[Jira Ticket](https://jira.corp.adobe.com/browse/DEVSITE-1192)

## Motivation and Context
Icons should be able to have non-linked text associated with them without becoming huge.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

[PREVIEW HERE](https://devsite-1192--adobe-io-website--adobe.hlx.page/test/Eli/1192-icons)

[Current view](https://fresh-spectrum-less--adobe-io-website--adobe.hlx.page/test/Eli/1192-icons)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
