### PR TITLE
fix: Allowed hyperlinked images in carousel

### DIFF
--- a/hlx_statics/blocks/carousel/carousel.js
+++ b/hlx_statics/blocks/carousel/carousel.js
@@ -7,6 +7,7 @@ export default async function decorate(block) {
   block.setAttribute('daa-lh', 'carousel');
   removeEmptyPTags(block);
   decorateButtons(block);
+  reformatHyperlinkImages(block);
 
   const carousel_block_child = createTag('div', {class: 'block-container'});
   block.append(carousel_block_child);
@@ -64,12 +65,26 @@ export default async function decorate(block) {
 
   //add id to image and add image to left div
   block.querySelectorAll('img').forEach((img) => {
-    img.parentElement.parentElement.classList.add('IMAGE');
-    //add image to left div
-    let flex_div = createTag('div', { id: 'left-flex-div-'+img.parentElement.parentElement.parentElement.id});
-    img.parentElement.parentElement.parentElement.append(flex_div);
-    flex_div.append(img.parentElement.parentElement);
-    flex_div.classList.add('left-container');
+    // checks if dealing with a hyperlinked image
+    if (img.parentElement.parentElement.tagName === 'A')
+      {
+        // if so, adds an extra ".parentElement" becuase image is wrapped in ancor tag
+        img.parentElement.parentElement.parentElement.classList.add('IMAGE');
+        //add image to left div
+        let flex_div = createTag('div', { id: 'left-flex-div-'+img.parentElement.parentElement.parentElement.parentElement.id});
+        img.parentElement.parentElement.parentElement.parentElement.append(flex_div);
+        flex_div.append(img.parentElement.parentElement.parentElement);
+        flex_div.classList.add('left-container');
+      }
+      else
+      {
+        img.parentElement.parentElement.classList.add('IMAGE');
+        //add image to left div
+        let flex_div = createTag('div', { id: 'left-flex-div-'+img.parentElement.parentElement.parentElement.id});
+        img.parentElement.parentElement.parentElement.append(flex_div);
+        flex_div.append(img.parentElement.parentElement);
+        flex_div.classList.add('left-container');
+      }
   });
 
   block.querySelectorAll('p').forEach(function (p){
@@ -124,6 +139,28 @@ export default async function decorate(block) {
     slide_selected.classList.remove('carousel-circle-selected');
     new_slide.classList.add('carousel-circle-selected');
   });
+
+
+  /** 
+   * For images that have hyperlinks attached to them in Google Docs, they are wrapped in an anchor tag, which messes up
+   * formatting the carousel slide. This function reformats the images/links so they are in a similar format to other slides
+  */
+  function reformatHyperlinkImages(block) {
+    // Selects all hyper linked images
+    block.querySelectorAll('div.embed.block > div > div > a').forEach( (a) => {
+      const picture = a.firstElementChild.firstElementChild;
+      a.append(picture);
+      a.removeChild(a.firstElementChild);
+      const paragraphWrapper = createTag('p', {});
+      // Because of link, image is surrounded by numerous divs. Navigates back up to OG parent
+      const newDivParent = a.parentElement.parentElement.parentElement.parentElement;
+      a.parentElement.removeChild(a);
+      paragraphWrapper.append(a);
+      // pulls out the old image container and replaces it with pargraph-wrapped image 
+      // Format is same as other slides
+      newDivParent.replaceChild(paragraphWrapper, newDivParent.firstElementChild);
+    });
+  }
 
   //change color of circle button when clicked
   const buttons = block.querySelectorAll('.carousel-circle');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed functionality for adding hyperlinked images into a carousel component.
Added reformatHyperlinkImages function to reformat HTML.
Added an if statement to create proper left/right containers for hyperlinked images

## Related Issue

Jira ticket: [link](https://jira.corp.adobe.com/browse/DEVSITE-1185)

## Motivation and Context

![image](https://github.com/user-attachments/assets/1f6c692b-fee3-48ba-8927-a6564cfa9fc0)

## How Has This Been Tested?

[test url](https://devsite-1185--adobe-io-website--adobe.hlx.page/test/Eli/1185)
[current implementation](https://fresh-spectrum-less--adobe-io-website--adobe.hlx.page/test/Eli/1185)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
