### PR TITLE
calendar styling

### DIFF
--- a/hlx_statics/blocks/calendar/calendar.css
+++ b/hlx_statics/blocks/calendar/calendar.css
@@ -1,0 +1,12 @@
+main div.calendar .iframe-container {
+  width: var(--spectrum-global-dimension-static-grid-fixed-max-width);
+  height: calc(100vh - var(--spectrum-global-dimension-size-800));
+  border: none;  
+}
+
+main div.calendar .calendar-block {
+  display: flex;
+  flex-direction: row ;
+  justify-content: center;
+  position: relative;
+}

--- a/hlx_statics/blocks/calendar/calendar.js
+++ b/hlx_statics/blocks/calendar/calendar.js
@@ -1,0 +1,19 @@
+import { createTag, removeEmptyPTags } from '../../scripts/lib-adobeio.js';
+/**
+ * decorates the calendar
+ * @param {Element} block The calendar block element
+ */
+export default async function decorate(block) {
+  block.setAttribute('daa-lh', 'calendar');
+  removeEmptyPTags(block);
+
+  const calendar_iframe = createTag('iframe', {class: 'iframe-container'});
+
+  block.querySelectorAll('a').forEach((a) => {
+    const link = a.href;
+    a.parentElement.replaceWith(calendar_iframe);
+    calendar_iframe.src = link;
+    calendar_iframe.parentElement.classList.add('calendar-block');
+
+  });
+}


### PR DESCRIPTION
Calendar block: add url to display a Google calendar or an Airtable calendar

## Description

Added styling to the iFrame that contains a calendar (Google or Airtable) so that it no longer takes up the whole screen

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
