### PR TITLE
fix: hero browser error

### DIFF
--- a/hlx_statics/blocks/hero/hero.js
+++ b/hlx_statics/blocks/hero/hero.js
@@ -23,7 +23,6 @@ function rearrangeLinks(block) {
  * @param {Element} block The hero block element
  */
 export default async function decorate(block) {
-
   block.setAttribute('daa-lh', 'hero');
   // Block decoration
   decorateLightOrDark(block, true);
@@ -40,7 +39,6 @@ export default async function decorate(block) {
     } else {
       h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL', 'spectrum-Heading--serif');
     }
-
   });
 
   block.querySelectorAll('picture source').forEach((picture) => {
@@ -72,48 +70,46 @@ export default async function decorate(block) {
     heroWrapper.querySelectorAll('.hero-container > div').forEach((herowrapper) => {
       Object.assign(herowrapper.style, {
         backgroundImage: `url(${backgroundImage})`,
-        backgroundRepeat: "no-repeat",
-        backgroundSize: "cover",
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: 'cover',
       });
-    })
+    });
     heroWrapper.querySelectorAll('.hero-container > div > div').forEach((herowrapper) => {
       Object.assign(herowrapper.style, {
         backgroundColor: 'transparent',
         width: '75%',
-        margin: 'auto'
+        margin: 'auto',
       });
-    })
+    });
   }
   if (fontColor) {
     block.querySelectorAll('h1, p, a, span').forEach((font) => {
       font.style.setProperty('color', fontColor, 'important');
-    })
+    });
   }
   block.querySelectorAll('img').forEach((img) => {
     if (blockImageWidth) {
       Object.assign(img.style, {
         width: blockImageWidth,
-        objectFit: 'contain'
-      })
-    }
-    else {
+        objectFit: 'contain',
+      });
+    } else {
       Object.assign(img.style, {
         width: '600px',
         height: '400px',
-        objectFit: 'contain'
-      })
+        objectFit: 'contain',
+      });
     }
-  })
+  });
 
-  if (blockImage.toLocaleLowerCase() === "visible") {
+  if (blockImage.toLocaleLowerCase() === 'visible') {
     heroWrapper.querySelectorAll('picture').forEach((picture) => {
-      picture.style.setProperty('display', "block", 'important');
+      picture.style.setProperty('display', 'block', 'important');
     });
     heroWrapper.querySelectorAll('main div.hero div:nth-child(2)').forEach((picture) => {
-      picture.style.setProperty('display', "block", 'important');
-    })
+      picture.style.setProperty('display', 'block', 'important');
+    });
   }
-
 
   applyAnalyticHeaderOverride(block);
 }

--- a/hlx_statics/blocks/hero/hero.js
+++ b/hlx_statics/blocks/hero/hero.js
@@ -102,7 +102,7 @@ export default async function decorate(block) {
     }
   });
 
-  if (blockImage.toLocaleLowerCase() === 'visible') {
+  if (blockImage?.toLocaleLowerCase() === 'visible') {
     heroWrapper.querySelectorAll('picture').forEach((picture) => {
       picture.style.setProperty('display', 'block', 'important');
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Check for null to prevent browser error logged to console:
<img width="1471" alt="Screenshot 2024-09-25 at 10 11 02 AM" src="https://github.com/user-attachments/assets/8c1de3dd-8a69-4230-ba91-c0979ea89b27">


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Console error: failed to load module for hero TypeError: Cannot read properties of null (reading 'toLocaleLowerCase')

- Before (has above console error): https://fresh-spectrum-less--adobe-io-website--adobe.hlx.page/tools/sidekick/blocks/hero?nocache=1727121539864

- After (doesn't have above console error): https://second-pass-hero--adobe-io-website--adobe.hlx.page/tools/sidekick/blocks/hero?nocache=1727121539864

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
